### PR TITLE
Add invalidateData() hook for meteor tables

### DIFF
--- a/packages/meteor/src/MeteorDataFetcher.ts
+++ b/packages/meteor/src/MeteorDataFetcher.ts
@@ -35,4 +35,9 @@ export interface MeteorDataFetcher<Q, D extends object> {
      * @param done must be called when the request is done.
      */
     callFetchData(query: Q, done: MeteorDataFetcherDone<D>): void;
+
+    /**
+     * This method should indicate if our data become "dirty"
+     */
+    invalidateData(): void;
 }

--- a/packages/meteor/src/MeteorTableImpl.ts
+++ b/packages/meteor/src/MeteorTableImpl.ts
@@ -3,6 +3,7 @@ import { Mongo } from 'meteor/mongo';
 import { MeteorDataFetcherDone } from './MeteorDataFetcher';
 import { MeteorTableData, MeteorTableFetcher, MeteorTableQuery } from './MeteorTableFetcher';
 import { MeteorTableFetcherImpl } from './MeteorTableFetcherImpl';
+import { MeteorTableOperations } from './MeteorTableOperations';
 
 function sortToMongo(sort: SortColumn[]): Mongo.SortSpecifier {
     // tslint:disable-next-line:no-inferred-empty-object-type
@@ -21,7 +22,7 @@ export interface MeteorTableOptions<T> extends Omit<TableOptions<T>, 'data' | 'r
 /**
  * This is heavy expression stuff looking really ugly -- may need some rework!
  */
-export class MeteorTableImpl<T> extends TableImpl<T> {
+export class MeteorTableImpl<T> extends TableImpl<T> implements MeteorTableOperations {
     private readonly meteorImpl: MeteorTableOptions<T>;
     constructor(impl: MeteorTableOptions<T>) {
         // here we implement everything that we can implement
@@ -71,5 +72,8 @@ export class MeteorTableImpl<T> extends TableImpl<T> {
             return t(toId(this.id + '.serverError.' + error), error);
         }
         return super.getErrors();
+    }
+    public invalidateData() {
+        this.tableFetcher.invalidateData();
     }
 }

--- a/packages/meteor/src/MeteorTableOperations.ts
+++ b/packages/meteor/src/MeteorTableOperations.ts
@@ -1,0 +1,6 @@
+export interface MeteorTableOperations {
+    /**
+     * Method to set the "dirty" bit on the displayed data
+     */
+    invalidateData(): void;
+}

--- a/packages/meteor/src/MethodDataFetcherImpl.ts
+++ b/packages/meteor/src/MethodDataFetcherImpl.ts
@@ -128,4 +128,8 @@ export abstract class MethodDataFetcherImpl<Q, D extends Object> implements Mete
      * @returns {D}
      */
     abstract getInitialData(): D;
+
+    public invalidateData(): void {
+        this.runDataFetcherFunction();
+    }
 }

--- a/packages/meteor/src/index.ts
+++ b/packages/meteor/src/index.ts
@@ -3,6 +3,7 @@ export * from './MeteorDataFetcher';
 export * from './MeteorSubscription';
 export * from './MeteorDependencies';
 export * from './MeteorSubscriptionImpl';
+export * from './MeteorTableOperations';
 export * from './MeteorTableFetcher';
 export * from './MeteorTableImpl';
 export * from './MeteorTableFetcherImpl';

--- a/packages/moxb/src/table/TableImpl.ts
+++ b/packages/moxb/src/table/TableImpl.ts
@@ -1,4 +1,4 @@
-import { action, computed, observable } from 'mobx';
+import { computed } from 'mobx';
 import { Table } from './Table';
 import { TableColumn } from './TableColumn';
 import { TablePagination } from './TablePagination';
@@ -30,14 +30,8 @@ export class TableImpl<T> extends BindImpl<TableOptions<T>> implements Table<T> 
         return this.getReady();
     }
 
-    // ToDo: write a higher order function to compass
-    // ToDo: the if impl.func call the impl.func otherwise return something
-    // ToDo: Or just simply use the ?: operators and it is a one-liner
     protected getReady(): boolean {
-        if (this.impl.ready) {
-            return this.impl.ready(this);
-        }
-        return true;
+        return this.impl.ready ? this.impl.ready(this) : true;
     }
 
     @computed
@@ -46,10 +40,7 @@ export class TableImpl<T> extends BindImpl<TableOptions<T>> implements Table<T> 
     }
 
     protected getColumns(): TableColumn[] {
-        if (this.impl.columns) {
-            return this.impl.columns(this);
-        }
-        return [];
+        return this.impl.columns ? this.impl.columns(this) : [];
     }
 
     @computed
@@ -58,10 +49,7 @@ export class TableImpl<T> extends BindImpl<TableOptions<T>> implements Table<T> 
     }
 
     protected getData(): T[] {
-        if (this.impl.data) {
-            return this.impl.data(this);
-        }
-        return [];
+        return this.impl.data ? this.impl.data(this) : [];
     }
 
     @computed


### PR DESCRIPTION
This PR is a prerequisite for https://app.zenhub.com/workspace/o/go-e/ves/issues/77.

Besides some minor improvements, this PR introduces the concept of `invalidateData` on the `MeteorDataFetcher` interface, which method should be used to signal that the currently displayed data is no longer correct.

In the implementation, `MeteorDataFetcherImpl` implements this function by running the `runDataFetcherFunction()`

That is all nice, but we have to be able to trigger this from `MeteorTableImpl` for which I added a new interface called `MeteorTableOperations` to implement and it calls the `this.tableFetcher.invalidateData();`

I think that this invalidateData does not belong to the `Table` interface itself, so a separate interface was needed.

@scharf : What do you think?