### PR TITLE
[WIP, demo only] Native routing

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -23,7 +23,7 @@ all: build
 .PHONY: build
 build:  all-dependencies npm-link-dependencies
 	$(ACTIVATE) \
-		&& $(PARCEL) build index.html
+		&& $(PARCEL) build src/ant/index.html
 
 .PHONY: clean-build
 clean-dist:
@@ -74,10 +74,17 @@ npm-link-dependencies:
 ########################################################################################################################
 ##### Begin tsc ###################################################################################################
 
-.PHONY: watch
-watch:  all-dependencies npm-link-dependencies
+watch: watch-antd
+
+.PHONY: watch-antd
+watch-antd:  all-dependencies npm-link-dependencies
 	$(ACTIVATE) \
-		&& $(PARCEL) index.html
+		&& cd src/antd && ../../$(PARCEL) index.html
+
+.PHONY: watch-semui
+watch-semui:  all-dependencies npm-link-dependencies
+	$(ACTIVATE) \
+		&& cd src/semui && ../../$(PARCEL) index.html
 
 .PHONY: clean-generated-js-files
 clean-generated-js-files:

--- a/examples/index.html
+++ b/examples/index.html
@@ -15,7 +15,7 @@
     <br>
     <ul>
         <li><a href="src/indexUi.html">Semantic UI components</a></li>
-        <li><a href="src/indexAnt.html">Ant design components</a></li>
+        <li><a href="src/ant/index.html">Ant design components</a></li>
     </ul>
 </body>
 </html>

--- a/examples/src/antd/index.html
+++ b/examples/src/antd/index.html
@@ -3,8 +3,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <title>moxb examples - Ant design components</title>
-    <link rel="shortcut icon" type="image/x-icon" href="../favicon.ico">
-    <link href="../index.style.less" rel="stylesheet">
+    <link rel="shortcut icon" type="image/x-icon" href="../../favicon.ico">
+    <link href="../../index.style.less" rel="stylesheet">
     <style>
         html { padding: 30px; font-family: "Helvetica Neue", sans-serif; }
         li { padding: 5px 0; }
@@ -15,6 +15,6 @@
 
 <body>
     <div id="example-app"></div>
-    <script src="indexAnt.tsx"></script>
+    <script src="../indexAnt.tsx"></script>
 </body>
 </html>

--- a/examples/src/semui/index.html
+++ b/examples/src/semui/index.html
@@ -3,7 +3,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <title>moxb examples - Semantic UI</title>
-    <link rel="shortcut icon" type="image/x-icon" href="../favicon.ico">
+    <link rel="shortcut icon" type="image/x-icon" href="../../favicon.ico">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/semantic-ui@2.3.3/dist/semantic.min.css">
 
     <style>
@@ -21,6 +21,6 @@
         integrity="sha256-hVVnYaiADRTO2PzUGmuLJr8BLUSjGIZsDYGmIJLv2b8="
         crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/semantic-ui@2.3.3/dist/semantic.min.js"></script>
-    <script src="indexUi.tsx"></script>
+    <script src="../indexUi.tsx"></script>
 </body>
 </html>

--- a/examples/src/store/LocationStoreImpl.ts
+++ b/examples/src/store/LocationStoreImpl.ts
@@ -1,7 +1,8 @@
 // import { createMemoryHistory } from 'history';
 import {
     BasicLocationManagerImpl,
-    QueryBasedUrlSchema,
+    NativeUrlSchema,
+    // QueryBasedUrlSchema,
     // HashBasedUrlSchema,
 } from '@moxb/moxb';
 
@@ -9,9 +10,9 @@ export class LocationStoreImpl extends BasicLocationManagerImpl {
     public constructor() {
         super({
             // history: createMemoryHistory(),
-            //            urlSchema: new NativeUrlSchema(),
-            urlSchema: new QueryBasedUrlSchema(),
-            // urlSchema: new HashBasedUrlSchema(),
+            urlSchema: new NativeUrlSchema(),
+            //            urlSchema: new QueryBasedUrlSchema(),
+            //            urlSchema: new HashBasedUrlSchema(),
         });
 
         this.setRedirect({


### PR DESCRIPTION
This is a version of the routing PR (https://github.com/moxb/moxb/pull/41) which supports "native" routing, that is, putting the path into the actual path (like `http://localhost:1234/loginForm`), as opposed to the (more widely compatible) query-based routing (like `http://localhost:1234/index.html?path=loginForm`)

The downside is that this way we can't serve multiple HTML files at once (with parcel), so we can't run the SemUI and the AntD demo at the same time. Currently, only the AntD version is run.