### PR TITLE
Args parser does not use memorize

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7108,11 +7108,6 @@
         "lodash.isarray": "^3.0.0"
       }
     },
-    "lodash.memoize": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
-    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",

--- a/packages/moxb/package.json
+++ b/packages/moxb/package.json
@@ -57,7 +57,6 @@
   },
   "dependencies": {
     "history": "4.7.2",
-    "lodash.memoize": "^4.1.2",
     "urijs": "^1.19.1"
   }
 }

--- a/packages/moxb/src/routing/url-arg/UrlArgTypes.ts
+++ b/packages/moxb/src/routing/url-arg/UrlArgTypes.ts
@@ -22,7 +22,7 @@ export const URLARG_TYPE_BOOLEAN: UrlArgTypeDef<boolean> = {
  * Ordered string list URL arguments
  */
 export const URLARG_TYPE_ORDERED_STRING_ARRAY: UrlArgTypeDef<string[]> = {
-    getParser: () => (v, defaultValue) => (v.length ? v.split(',') : defaultValue),
+    getParser: () => (v, defaultValue) => (v.length ? v.split(',') : defaultValue.slice()),
     isEqual: (v1, v2) => v1.join(',') === v2.join(','),
     format: v => v.join(','),
 };
@@ -37,7 +37,7 @@ const formatOrderedArray = (v: string[]) =>
  * Unordered string array URL arguments
  */
 export const URLARG_TYPE_UNORDERED_STRING_ARRAY: UrlArgTypeDef<string[]> = {
-    getParser: () => (v, defaultValue) => (v.length ? v.split(',') : defaultValue).slice().sort(),
+    getParser: () => (v, defaultValue) => (v.length ? v.split(',') : defaultValue.slice()).sort(),
     isEqual: (v1, v2) => formatOrderedArray(v1) === formatOrderedArray(v2),
     format: formatOrderedArray,
 };

--- a/packages/moxb/src/routing/url-arg/UrlArgTypes.ts
+++ b/packages/moxb/src/routing/url-arg/UrlArgTypes.ts
@@ -1,4 +1,3 @@
-import memoize = require('lodash.memoize');
 import { UrlArgTypeDef } from './UrlArg';
 
 /**
@@ -14,49 +13,33 @@ export const URLARG_TYPE_STRING: UrlArgTypeDef<string> = {
  * Boolean URL arguments
  */
 export const URLARG_TYPE_BOOLEAN: UrlArgTypeDef<boolean> = {
-    getParser: () => memoize((v: string) => v === 'true'),
+    getParser: () => v => v === 'true',
     isEqual: (v1, v2) => !!v1 === !!v2,
     format: v => v.toString(),
-};
-
-const empty: string[] = [];
-
-// @ts-ignore
-const createStringArrayParser = (_key: string) => {
-    const parser = memoize(
-        (v: string, _defaultValue: any): string[] => {
-            const result = v.length ? v.split(',').slice() : empty;
-            return result;
-        },
-        v => v.toString()
-    );
-    return parser;
 };
 
 /**
  * Ordered string list URL arguments
  */
 export const URLARG_TYPE_ORDERED_STRING_ARRAY: UrlArgTypeDef<string[]> = {
-    getParser: memoize(key => createStringArrayParser(key)),
-    isEqual: (v1, v2) => v1.slice().join(',') === v2.slice().join(','),
+    getParser: () => (v, defaultValue) => (v.length ? v.split(',') : defaultValue),
+    isEqual: (v1, v2) => v1.join(',') === v2.join(','),
     format: v => v.join(','),
 };
+
+const formatOrderedArray = (v: string[]) =>
+    v
+        .slice()
+        .sort()
+        .join(',');
 
 /**
  * Unordered string array URL arguments
  */
 export const URLARG_TYPE_UNORDERED_STRING_ARRAY: UrlArgTypeDef<string[]> = {
-    getParser: memoize(key => createStringArrayParser(key)),
-    isEqual: (v1, v2) =>
-        v1
-            .slice()
-            .sort()
-            .join(',') ===
-        v2
-            .slice()
-            .sort()
-            .join(','),
-    format: v => v.join(','),
+    getParser: () => (v, defaultValue) => (v.length ? v.split(',') : defaultValue).slice().sort(),
+    isEqual: (v1, v2) => formatOrderedArray(v1) === formatOrderedArray(v2),
+    format: formatOrderedArray,
 };
 
 /**
@@ -76,7 +59,7 @@ export function URLARG_TYPE_OBJECT<T>(): UrlArgTypeDef<T> {
     };
 
     return {
-        getParser: () => memoize(parser),
+        getParser: () => parser,
         isEqual: (v1, v2) => JSON.stringify(v1) === JSON.stringify(v2),
         format: v => btoa(JSON.stringify(v)),
     };
@@ -87,6 +70,6 @@ export function URLARG_TYPE_OBJECT<T>(): UrlArgTypeDef<T> {
  */
 export const URLARG_TYPE_URLENCODED: UrlArgTypeDef<string> = {
     format: encodeURIComponent,
-    getParser: () => memoize(decodeURIComponent),
+    getParser: () => decodeURIComponent,
     isEqual: (v1, v2) => v1 === v2,
 };

--- a/packages/moxb/src/routing/url-arg/__tests__/UrlArgTypeOrderedStringArray.test.ts
+++ b/packages/moxb/src/routing/url-arg/__tests__/UrlArgTypeOrderedStringArray.test.ts
@@ -1,6 +1,6 @@
 import { URLARG_TYPE_ORDERED_STRING_ARRAY } from '../UrlArgTypes';
 
-describe('URL arg type boolean', () => {
+describe('URL arg type ordered string array', () => {
     const typeDef = URLARG_TYPE_ORDERED_STRING_ARRAY;
     const parser = typeDef.getParser('test');
 
@@ -12,14 +12,34 @@ describe('URL arg type boolean', () => {
         expect(parser('a,b,c', ['42'])).toEqual(['a', 'b', 'c']);
     });
 
-    it('should return the same array instance on subsequent calls with the same string', () => {
+    it('should return the equal array instance on subsequent calls with the same string', () => {
         const v1 = parser('a,b,c', ['42']);
         const v2 = parser('a,b,c', ['42']);
-        expect(v1).toBe(v2); // The objects are actually the same, not only equal!
+        expect(v1).toEqual(v2);
+    });
+
+    it('should return the equal array instance on subsequent calls with the same string for the same param', () => {
+        const v1 = typeDef.getParser('test')('a,b,c', ['42']);
+        const v2 = typeDef.getParser('test')('a,b,c', ['42']);
+        expect(v1).toEqual(v2);
+    });
+
+    it('should return the not equal array if order changes', () => {
+        const v1 = typeDef.getParser('test')('a,b,c', ['42']);
+        const v2 = typeDef.getParser('x')('a,b,c', ['42']);
+        expect(v1).toEqual(v2);
+    });
+
+    it('should return the same array instance on subsequent calls with the same string for the different params', () => {
+        const v1 = typeDef.getParser('test')('a,b,c', ['42']);
+        const v2 = typeDef.getParser('x')('a,b,c', ['42']);
+        expect(v1).toEqual(v2);
     });
 
     it('should be able to parse empty strings', () => {
-        expect(parser('', ['42'])).toEqual([]);
+        expect(parser('', ['42'])).toEqual(['42']);
+        const defaultValue = ['1'];
+        expect(parser('', defaultValue)).toBe(defaultValue);
     });
 
     it('should consider the order of elements', () => {

--- a/packages/moxb/src/routing/url-arg/__tests__/UrlArgTypeOrderedStringArray.test.ts
+++ b/packages/moxb/src/routing/url-arg/__tests__/UrlArgTypeOrderedStringArray.test.ts
@@ -36,10 +36,17 @@ describe('URL arg type ordered string array', () => {
         expect(v1).toEqual(v2);
     });
 
-    it('should be able to parse empty strings', () => {
+    it('should return default value', () => {
         expect(parser('', ['42'])).toEqual(['42']);
         const defaultValue = ['1'];
-        expect(parser('', defaultValue)).toBe(defaultValue);
+        expect(parser('', defaultValue)).toEqual(defaultValue);
+    });
+
+    it('should return copy of default value', () => {
+        const defaultValue = ['1', '2'];
+        const v = parser('', defaultValue);
+        expect(v).toEqual(defaultValue);
+        expect(v).not.toBe(defaultValue);
     });
 
     it('should consider the order of elements', () => {

--- a/packages/moxb/src/routing/url-arg/__tests__/UrlArgTypeUnorderedStringArray.test.ts
+++ b/packages/moxb/src/routing/url-arg/__tests__/UrlArgTypeUnorderedStringArray.test.ts
@@ -41,6 +41,19 @@ describe('URL arg type unordered string array', () => {
         expect(parser('', ['42'])).toEqual(['42']);
     });
 
+    it('should return copy of default value', () => {
+        const defaultValue = ['1', '2'];
+        const v = parser('', defaultValue);
+        expect(v).toEqual(defaultValue);
+        expect(v).not.toBe(defaultValue);
+    });
+
+    it('should sort default value but not change it', () => {
+        const defaultValue = ['z', 'a'];
+        expect(parser('', defaultValue)).toEqual(['a', 'z']);
+        expect(defaultValue).toEqual(['z', 'a']);
+    });
+
     it('should ignore the order of elements', () => {
         expect(typeDef.isEqual(['a', 'b'], ['b', 'a'])).toBeTruthy();
     });

--- a/packages/moxb/src/routing/url-arg/__tests__/UrlArgTypeUnorderedStringArray.test.ts
+++ b/packages/moxb/src/routing/url-arg/__tests__/UrlArgTypeUnorderedStringArray.test.ts
@@ -1,6 +1,6 @@
 import { URLARG_TYPE_UNORDERED_STRING_ARRAY } from '../UrlArgTypes';
 
-describe('URL arg type boolean', () => {
+describe('URL arg type unordered string array', () => {
     const typeDef = URLARG_TYPE_UNORDERED_STRING_ARRAY;
     const parser = typeDef.getParser('test');
 
@@ -15,11 +15,30 @@ describe('URL arg type boolean', () => {
     it('should return the same array instance on subsequent calls with the same string', () => {
         const v1 = parser('a,b,c', ['42']);
         const v2 = parser('a,b,c', ['42']);
-        expect(v1).toBe(v2); // The objects are actually the same, not only equal!
+        expect(v1).toEqual(v2);
+    });
+
+    it('should return the same array instance on subsequent calls with the same string for the same param', () => {
+        const v1 = typeDef.getParser('test')('a,b,c', ['42']);
+        const v2 = typeDef.getParser('test')('a,b,c', ['42']);
+        expect(v1).toEqual(v2);
+    });
+
+    it('should return the same array instance independent of order', () => {
+        // To be consistent, this should also be the same not equal! (else we can drop the entire sameness)...
+        const v1 = typeDef.getParser('test')('a,b,c', ['42']);
+        const v2 = typeDef.getParser('test')('c,a,b', ['42']);
+        expect(v1).toEqual(v2);
+    });
+
+    it('should return the same array instance on subsequent calls with the same string for the different params', () => {
+        const v1 = typeDef.getParser('test')('a,b,c', ['42']);
+        const v2 = typeDef.getParser('x')('a,b,c', ['42']);
+        expect(v1).toEqual(v2);
     });
 
     it('should be able to parse empty strings', () => {
-        expect(parser('', ['42'])).toEqual([]);
+        expect(parser('', ['42'])).toEqual(['42']);
     });
 
     it('should ignore the order of elements', () => {


### PR DESCRIPTION
`ves` does not work with the master version of `moxb`, because it complains about `lodash.memoize`. This problem does probably not happen, if we would install `moxb` the normal way. But the combination of `lerna` and linked packages causes problems.

However, I was looking why `moxb` needs `lodash.memoize`: it is needed by `UrlArgTypes.ts`.

Looking at the tests I discovered some inconsistencies: 

- sometimes the test requires the result of `parse()` to be the same, and sometimes it is not the same
- for unordered arrays, the order should not matter when `parse()` is called (the result should always be the same)
- the `defaultValue` was ignored for attray types

So, I thought, I would fix it (see PR #47), but that turns out to be more complicated. Therefore, I decided to drop the constraint (and `lodash.memoize`), that the args are the same and reduced it to just be equal.

I think there is a danger in `lodash.memoize` if we are not in a purely functional environment: if you change the returned array, then you change the cached value and all kind of evil things could happen:

```ts
const args = parse('a,b', []);
args[1] = 'OOPS';
parse('a,b', []); ==> ['a', 'OOPS']!
```

see [broken test in #47](https://github.com/moxb/moxb/pull/47/commits/5cadbdbec04bd886095abd31ad94697ae386ae6)