### PR TITLE
Replace wget with curl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ _check-for-only:
 
 .makehelper/node-installation: admin/node-installation/.node-version admin/node-installation/.npm-version admin/node-installation/install.sh
 	@echo "Installing node..."
-	@admin/bin/check-if-commands-exist.sh wget
+	@admin/bin/check-if-commands-exist.sh curl
 	@$(ACTIVATE) && admin/node-installation/install.sh
 	@touch $@
 

--- a/admin/node-installation/install.sh
+++ b/admin/node-installation/install.sh
@@ -25,7 +25,7 @@ rm -rf $INSTALLATION/installation
 mkdir -p $INSTALLATION/installation/current
 cd $INSTALLATION/installation
 
-wget $URL
+curl $URL --output $TAR
 
 tar -zxf $TAR --strip-components 1 -C current
 


### PR DESCRIPTION
In some networking circumstances, wget will simply hang indefinitely,
while curl simply works.

I didn't have time to debug this, but replacing wget with curl
solves the problem in 100% of the cases.