### PR TITLE
Improve the path token matching API

### DIFF
--- a/examples/src/app/AppRouterAnt.tsx
+++ b/examples/src/app/AppRouterAnt.tsx
@@ -15,7 +15,13 @@ export class AppRouterAnt extends React.Component<{ location?: LocationManager }
                     <Row>
                         <NavigationAnt />
                     </Row>
-                    <LocationDependentArea id="main area" subStates={mainMenu} fallback={defaultContent} part="main" />
+                    <LocationDependentArea
+                        id="main area"
+                        subStates={mainMenu}
+                        fallback={defaultContent}
+                        part="main"
+                        useTokenMappings={true}
+                    />
                     <hr />
                     <LocationDependentArea
                         id="footer area"

--- a/examples/src/app/AppRouterAnt.tsx
+++ b/examples/src/app/AppRouterAnt.tsx
@@ -15,9 +15,14 @@ export class AppRouterAnt extends React.Component<{ location?: LocationManager }
                     <Row>
                         <NavigationAnt />
                     </Row>
-                    <LocationDependentArea subStates={mainMenu} fallback={defaultContent} part="main" />
+                    <LocationDependentArea id="main area" subStates={mainMenu} fallback={defaultContent} part="main" />
                     <hr />
-                    <LocationDependentArea subStates={mainMenu} fallback={defaultContent} part="bottom" />
+                    <LocationDependentArea
+                        id="footer area"
+                        subStates={mainMenu}
+                        fallback={defaultContent}
+                        part="bottom"
+                    />
                 </Layout.Content>
             </Layout>
         );

--- a/examples/src/app/AppRouterAnt.tsx
+++ b/examples/src/app/AppRouterAnt.tsx
@@ -16,7 +16,7 @@ export class AppRouterAnt extends React.Component<{ location?: LocationManager }
                         <NavigationAnt />
                     </Row>
                     <LocationDependentArea
-                        id="main area"
+                        id="main-area"
                         subStates={mainMenu}
                         fallback={defaultContent}
                         part="main"
@@ -24,7 +24,7 @@ export class AppRouterAnt extends React.Component<{ location?: LocationManager }
                     />
                     <hr />
                     <LocationDependentArea
-                        id="footer area"
+                        id="footer-area"
                         subStates={mainMenu}
                         fallback={defaultContent}
                         part="bottom"

--- a/examples/src/menus/DetailDisplayer.tsx
+++ b/examples/src/menus/DetailDisplayer.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import { inject, observer } from 'mobx-react';
 import { UsesLocation, Navigable, getParsedPathTokens } from '@moxb/moxb';
-import { DetailProps, UIFragmentSpec } from '@moxb/antd';
+import { UIFragmentSpec } from '@moxb/antd';
+import { UsesURL } from '../store/UrlStore';
 
-@inject('locationManager')
+@inject('locationManager', 'url')
 @observer
-export class DetailDisplayer extends React.Component<Navigable<any, UIFragmentSpec> & UsesLocation & DetailProps> {
+export class DetailDisplayer extends React.Component<Navigable<any, UIFragmentSpec> & UsesLocation & UsesURL> {
     public render() {
         return (
             <div>
@@ -13,7 +14,7 @@ export class DetailDisplayer extends React.Component<Navigable<any, UIFragmentSp
                     We are at <b>{getParsedPathTokens(this.props).join(' / ')}</b>
                 </div>
                 <div>
-                    Displaying content for token <b>{this.props.token}</b>
+                    Displaying content for topic <b>{this.props.url!.something.value}</b>
                 </div>
             </div>
         );

--- a/examples/src/menus/MoreMenusAnt.tsx
+++ b/examples/src/menus/MoreMenusAnt.tsx
@@ -29,6 +29,7 @@ export class MoreMenusAnt extends React.Component<{ url?: UrlStore } & Navigable
                             parsedTokens={this.props.parsedTokens}
                             // arg={url!.number}
                             subStates={subMenu1}
+                            useTokenMappings={true}
                             fallback="Unknown number"
                             debug={false}
                         />

--- a/examples/src/menus/SubMenu.tsx
+++ b/examples/src/menus/SubMenu.tsx
@@ -41,6 +41,7 @@ export const subMenu1: StateSpace<string, UIFragmentSpec, {}> = [
     {
         key: 'three',
         label: 'Three',
+        tokenMapping: ['something'],
         fragment: rootOrDetails({
             ifRoot: {
                 fragment: (

--- a/examples/src/store/Store.ts
+++ b/examples/src/store/Store.ts
@@ -9,14 +9,13 @@ import { LocationStoreImpl } from './LocationStoreImpl';
 import { UrlStore } from './UrlStore';
 import { UrlStoreImpl } from './UrlStoreImpl';
 import { TokenManager, TokenManagerImpl } from '../../../packages/moxb/src/routing';
-import { mainMenu } from '../MenuStructure';
 
 export interface Store {
     readonly app: Application;
     readonly memTable: MemTable;
     readonly view: ViewStore;
     readonly locationManager: LocationManager;
-    readonly tokens: TokenManager;
+    readonly tokenManager: TokenManager;
     readonly url: UrlStore;
 }
 
@@ -25,16 +24,13 @@ export class StoreImpl implements Store {
     readonly memTable: MemTable;
     readonly view: ViewStore;
     readonly locationManager: LocationManager;
-    readonly tokens: TokenManager;
+    readonly tokenManager: TokenManager;
     readonly url: UrlStore;
 
     constructor() {
         this.locationManager = new LocationStoreImpl();
-        this.tokens = new TokenManagerImpl({
-            locationManager: this.locationManager,
-            subStates: mainMenu,
-        });
-        this.url = new UrlStoreImpl(this.locationManager, this.tokens);
+        this.tokenManager = new TokenManagerImpl(this.locationManager);
+        this.url = new UrlStoreImpl(this.locationManager, this.tokenManager);
         this.app = new ApplicationImpl();
         this.memTable = new MemTableImpl(this.url);
         this.view = new ViewStoreImpl();

--- a/examples/src/store/UrlStore.ts
+++ b/examples/src/store/UrlStore.ts
@@ -7,6 +7,7 @@ export interface UrlStore {
     readonly bindSearch: Text;
     readonly groupId: UrlArg<string>;
     readonly objectId: UrlArg<string>;
+    readonly something: UrlArg<string>;
 }
 
 export interface UsesURL {

--- a/examples/src/store/UrlStoreImpl.ts
+++ b/examples/src/store/UrlStoreImpl.ts
@@ -15,6 +15,7 @@ export class UrlStoreImpl implements UrlStore {
     readonly number: UrlArg<string>;
     readonly groupId: UrlArg<string>;
     readonly objectId: UrlArg<string>;
+    readonly something: UrlArg<string>;
 
     readonly bindSearch = new TextImpl({
         id: 'sampleSearch',
@@ -52,6 +53,12 @@ export class UrlStoreImpl implements UrlStore {
 
         this.objectId = new UrlTokenImpl(tokens, {
             key: 'objectId',
+            valueType: URLARG_TYPE_STRING,
+            defaultValue: '',
+        });
+
+        this.something = new UrlTokenImpl(tokens, {
+            key: 'something',
             valueType: URLARG_TYPE_STRING,
             defaultValue: '',
         });

--- a/packages/antd/src/not-antd/LocationDependentArea.tsx
+++ b/packages/antd/src/not-antd/LocationDependentArea.tsx
@@ -29,6 +29,11 @@ export interface LocationDependentAreaProps<DataType>
     fallback?: UIFragmentSpec;
 
     /**
+     * Should we use the token mappings defined for the sub-states?
+     */
+    useTokenMappings?: boolean;
+
+    /**
      * Should we mount (but hide) the content of all possible selections of the state space?
      *
      * This will pass an invisible = true parameter to all children. The children react to that.
@@ -43,7 +48,7 @@ export interface LocationDependentAreaProps<DataType>
     debug?: boolean;
 }
 
-@inject('locationManager')
+@inject('locationManager', 'tokenManager')
 @observer
 export class LocationDependentArea<DataType> extends React.Component<LocationDependentAreaProps<DataType>> {
     protected readonly _states: LocationDependentStateSpaceHandler<UIFragment, UIFragmentSpec, DataType>;
@@ -51,11 +56,23 @@ export class LocationDependentArea<DataType> extends React.Component<LocationDep
     public constructor(props: LocationDependentAreaProps<DataType>) {
         super(props);
 
-        const { id, part, fallback, mountAll, ...remnantProps } = props;
+        const { id, part, fallback, mountAll, useTokenMappings, ...remnantProps } = props;
         this._states = new LocationDependentStateSpaceHandlerImpl({
             ...remnantProps,
             id: 'changing content of ' + id,
         });
+    }
+
+    public componentDidMount() {
+        if (this.props.useTokenMappings) {
+            this._states.registerTokenMappings();
+        }
+    }
+
+    public componentWillUnmount() {
+        if (this.props.useTokenMappings) {
+            this._states.unregisterTokenMappings();
+        }
     }
 
     public debugLog(...messages: any[]) {

--- a/packages/moxb/src/routing/TokenManager.ts
+++ b/packages/moxb/src/routing/TokenManager.ts
@@ -1,9 +1,37 @@
 import { Query } from './url-schema/UrlSchema';
 import { UpdateMethod } from './location-manager';
+import { StateCondition, StateSpace } from './location-state-space/state-space/StateSpace';
 
+export interface TokenMappings<DataType> {
+    id: string;
+    subStates: StateSpace<any, any, DataType>;
+    parsedTokens: number;
+    filterCondition?: StateCondition<DataType>;
+}
+
+/**
+ * The task of the TokenManager (singleton) is to extract some named tokens
+ * from the string of path tokens.
+ *
+ * In order to do that, it must be aware of the current mappings
+ * between path tokens and names.
+ */
 export interface TokenManager {
+    // Maintaining the mappings
+    addMappings<DataType>(mappings: TokenMappings<DataType>): string;
+    removeMappings(mappingsId: string): void;
+
+    // Accessing tokens
+
     tokens: Query;
     setToken(key: string, value: any, updateMethod?: UpdateMethod): void;
 
     getURLForTokenChange(key: string, value: any): string;
+}
+
+/**
+ * The interface we use when injecting the Location Manager
+ */
+export interface UsesTokenManager {
+    tokenManager?: TokenManager;
 }

--- a/packages/moxb/src/routing/TokenManagerImpl.ts
+++ b/packages/moxb/src/routing/TokenManagerImpl.ts
@@ -1,47 +1,91 @@
-import { TokenManager } from './TokenManager';
+import { observable, computed, action } from 'mobx';
+import { TokenManager, TokenMappings } from './TokenManager';
 import { LocationManager, UpdateMethod } from './location-manager';
-import {
-    isTokenEmpty,
-    LocationDependentStateSpaceHandler,
-    LocationDependentStateSpaceHandlerImpl,
-    Navigable,
-    StateSpace,
-} from './index';
 import { Query } from './url-schema/UrlSchema';
+import { LocationDependentStateSpaceHandler, LocationDependentStateSpaceHandlerImpl } from './location-state-space';
+import { isTokenEmpty } from './tokens';
 
-interface TokenManagerProps<DataType> extends Navigable<any, DataType> {
-    locationManager: LocationManager;
-    subStates: StateSpace<any, any, DataType>;
+interface LiveTokenMappings<DataType> extends TokenMappings<DataType> {
+    states: LocationDependentStateSpaceHandler<any, any, DataType>;
 }
 
-export class TokenManagerImpl<DataType> implements TokenManager {
-    private readonly _states: LocationDependentStateSpaceHandler<any, any, DataType>;
-    private readonly _locationManager: LocationManager;
-    private readonly _parsedTokens: number;
+export class TokenManagerImpl implements TokenManager {
+    private readonly _mappings = observable.map<string, LiveTokenMappings<any>>();
 
-    constructor(props: TokenManagerProps<DataType>) {
-        const { locationManager, subStates, filterCondition, parsedTokens } = props;
-        this._locationManager = locationManager;
-        this._parsedTokens = parsedTokens || 0;
-        this._states = new LocationDependentStateSpaceHandlerImpl({
-            id: 'token manager',
-            locationManager,
-            subStates,
-            filterCondition: filterCondition,
-            parsedTokens,
-        });
+    constructor(private readonly _locationManager: LocationManager) {
+        // autorun(() => {
+        //     console.log('Tokens now:', this.tokens);
+        // });
     }
 
+    @action
+    addMappings<DataType>(mappings: TokenMappings<DataType>) {
+        const { id, subStates, parsedTokens = 0, filterCondition } = mappings;
+        let mappingsId = id;
+        while (this._mappings.get(mappingsId)) {
+            mappingsId = mappingsId + '_';
+        }
+        this._mappings.set(mappingsId, {
+            id,
+            subStates,
+            parsedTokens,
+            filterCondition,
+            states: new LocationDependentStateSpaceHandlerImpl({
+                id: 'token manager mappings ' + id,
+                locationManager: this._locationManager,
+                subStates,
+                filterCondition,
+                parsedTokens,
+            }),
+        });
+        // console.log('Added path token mappings', mappingsId);
+        return mappingsId;
+    }
+
+    @action
+    removeMappings(mappingsId: string) {
+        // console.log('Removing mappings', mappingsId);
+        this._mappings.delete(mappingsId);
+    }
+
+    @computed
+    private get _activeMappings(): LiveTokenMappings<any> | undefined {
+        let result: LiveTokenMappings<any> | undefined = undefined;
+
+        Array.from(this._mappings.values()).forEach(mapping => {
+            const active = true;
+            // console.log("Is mapping '" + mapping.id + "' active?", active);
+            if (!active) {
+                return;
+            }
+            if (!result || mapping.parsedTokens > result.parsedTokens) {
+                result = mapping;
+            }
+        });
+        // if (result) {
+        //     console.log("Using mapping '" + result!.id + "'");
+        // } else {
+        //     console.log('No valid mappings found');
+        // }
+        return result;
+    }
+
+    @computed
     get tokens() {
         const result: Query = {};
-        const state = this._states.getActiveSubState();
+        const allTokens = this._locationManager.pathTokens;
+        const mappings = this._activeMappings;
+        if (!mappings) {
+            console.warn("Can't find any active mappings, not parsing path tokens");
+            return result;
+        }
+        const state = mappings.states.getActiveSubState();
         if (state) {
-            const allTokens = this._locationManager.pathTokens;
             const { tokenMapping, totalPathTokens } = state;
             if (!tokenMapping) {
                 return result;
             }
-            const parsedTokens = this._parsedTokens + totalPathTokens.length;
+            const parsedTokens = mappings.parsedTokens + totalPathTokens.length;
             tokenMapping.forEach((key, index) => {
                 result[key] = allTokens[parsedTokens + index];
             });
@@ -50,7 +94,12 @@ export class TokenManagerImpl<DataType> implements TokenManager {
     }
 
     public setToken(key: string, value: string, updateMethod?: UpdateMethod) {
-        const state = this._states.getActiveSubState();
+        const mappings = this._activeMappings;
+        if (!mappings) {
+            console.warn("Can't find any active mappings, not setting any tokens");
+            return;
+        }
+        const state = mappings.states.getActiveSubState();
         if (state) {
             const { tokenMapping, totalPathTokens } = state;
             if (!tokenMapping) {
@@ -62,7 +111,7 @@ export class TokenManagerImpl<DataType> implements TokenManager {
                 console.warn('No mapping for found for token ' + key);
                 return;
             }
-            const parsedTokens = this._parsedTokens + totalPathTokens.length;
+            const parsedTokens = mappings.parsedTokens + totalPathTokens.length;
             const localTokens = this._locationManager.pathTokens.slice(parsedTokens);
             for (let i = 0; i < index; i++) {
                 if (isTokenEmpty(localTokens[i])) {
@@ -79,34 +128,35 @@ export class TokenManagerImpl<DataType> implements TokenManager {
         }
     }
 
-    public getURLForTokenChange(key: string, value: string) {
-        const state = this._states.getActiveSubState();
-        if (state) {
-            const { tokenMapping, totalPathTokens } = state;
-            if (!tokenMapping) {
-                console.warn("No mappings for this state, can't calculate URL!");
-                return '';
-            }
-            const index = tokenMapping.indexOf(key);
-            if (index === -1) {
-                console.warn('No mapping for found for token ' + key);
-                return '';
-            }
-            const parsedTokens = this._parsedTokens + totalPathTokens.length;
-            const allTokens = this._locationManager.pathTokens;
-            const localTokens = allTokens.slice(parsedTokens);
-            for (let i = 0; i < index; i++) {
-                if (isTokenEmpty(localTokens[i])) {
-                    console.warn("Previous tokens are missing, can't set" + key);
-                    return '';
-                }
-            }
-            localTokens[index] = value;
-            localTokens.splice(index + 1);
-            return this._locationManager.getURLForPathTokens(parsedTokens, localTokens);
-        } else {
-            console.warn("Invalid state, can't calculate URL!");
-            return '';
-        }
+    public getURLForTokenChange(_key: string, _value: string) {
+        return 'asd';
+        // const state = this._states.getActiveSubState();
+        // if (state) {
+        //     const { tokenMapping, totalPathTokens } = state;
+        //     if (!tokenMapping) {
+        //         console.warn("No mappings for this state, can't calculate URL!");
+        //         return '';
+        //     }
+        //     const index = tokenMapping.indexOf(key);
+        //     if (index === -1) {
+        //         console.warn('No mapping for found for token ' + key);
+        //         return '';
+        //     }
+        //     const parsedTokens = this._parsedTokens + totalPathTokens.length;
+        //     const allTokens = this._locationManager.pathTokens;
+        //     const localTokens = allTokens.slice(parsedTokens);
+        //     for (let i = 0; i < index; i++) {
+        //         if (isTokenEmpty(localTokens[i])) {
+        //             console.warn("Previous tokens are missing, can't set" + key);
+        //             return '';
+        //         }
+        //     }
+        //     localTokens[index] = value;
+        //     localTokens.splice(index + 1);
+        //     return this._locationManager.getURLForPathTokens(parsedTokens, localTokens);
+        // } else {
+        //     console.warn("Invalid state, can't calculate URL!");
+        //     return '';
+        // }
     }
 }

--- a/packages/moxb/src/routing/location-state-space/LocationDependentStateSpaceHandler.ts
+++ b/packages/moxb/src/routing/location-state-space/LocationDependentStateSpaceHandler.ts
@@ -4,10 +4,12 @@ import { UsesLocation } from '../location-manager';
 import { UrlArg } from '../url-arg';
 import { Navigable } from '../navigable';
 import { SubStateInContext } from './state-space/StateSpace';
+import { UsesTokenManager } from '../TokenManager';
 
 export interface LocationDependentStateSpaceHandlerProps<LabelType, WidgetType, DataType>
     extends StateSpaceHandlerProps<LabelType, WidgetType, DataType>,
         UsesLocation,
+        UsesTokenManager,
         Navigable<WidgetType, DataType> {
     /**
      * The URL argument (if any) driving this component.
@@ -28,6 +30,16 @@ export interface LocationDependentStateSpaceHandlerProps<LabelType, WidgetType, 
  */
 export interface LocationDependentStateSpaceHandler<LabelType, WidgetType, DataType>
     extends StateSpaceHandler<LabelType, WidgetType, DataType> {
+    /**
+     * Register the mappings belonging to this state sub-tree on the token manegr
+     */
+    registerTokenMappings(): void;
+
+    /**
+     * Unregister token mappings
+     */
+    unregisterTokenMappings(): void;
+
     /**
      * Is this SubState currently active? (Given the location.)
      */

--- a/packages/moxb/src/routing/location-state-space/LocationDependentStateSpaceHandlerImpl.ts
+++ b/packages/moxb/src/routing/location-state-space/LocationDependentStateSpaceHandlerImpl.ts
@@ -1,4 +1,4 @@
-import { LocationManager, UpdateMethod } from '../location-manager/LocationManager';
+import { LocationManager, UpdateMethod } from '../location-manager';
 import {
     LocationDependentStateSpaceHandler,
     LocationDependentStateSpaceHandlerProps,
@@ -7,6 +7,7 @@ import { StateSpaceHandlerImpl } from './state-space/StateSpaceHandlerImpl';
 import { UrlArg, UrlArgImpl, URLARG_TYPE_ORDERED_STRING_ARRAY } from '../url-arg';
 import { SubStateInContext } from './state-space/StateSpace';
 import { updateTokenString } from '../tokens';
+import { TokenManager } from '../TokenManager';
 
 /**
  * This is the standard implementation of the StateSpaceAndLocationHandler.
@@ -17,13 +18,16 @@ export class LocationDependentStateSpaceHandlerImpl<LabelType, WidgetType, DataT
     extends StateSpaceHandlerImpl<LabelType, WidgetType, DataType>
     implements LocationDependentStateSpaceHandler<LabelType, WidgetType, DataType> {
     protected readonly _locationManager: LocationManager;
+    protected readonly _tokenManager: TokenManager;
     protected readonly _urlArg?: UrlArg<string[]>;
     protected readonly _parsedTokens: number;
+    protected _mappingId?: string;
 
     public constructor(props: LocationDependentStateSpaceHandlerProps<LabelType, WidgetType, DataType>) {
         super(props);
-        const { locationManager, parsedTokens, arg } = props;
+        const { locationManager, tokenManager, parsedTokens, arg } = props;
         this._locationManager = locationManager!;
+        this._tokenManager = tokenManager!;
         this._urlArg = arg
             ? new UrlArgImpl(locationManager!, {
                   key: arg.key,
@@ -39,6 +43,19 @@ export class LocationDependentStateSpaceHandlerImpl<LabelType, WidgetType, DataT
             console.log('Parsed tokens for state-space-and-location-handler', this._id, ':', this._parsedTokens);
         }
         this.isSubStateActive = this.isSubStateActive.bind(this);
+    }
+
+    public registerTokenMappings() {
+        this._mappingId = this._tokenManager.addMappings({
+            id: 'mappings for ' + this._id,
+            subStates: this._subStates,
+            parsedTokens: this._parsedTokens,
+            filterCondition: this._filterCondition,
+        });
+    }
+
+    public unregisterTokenMappings() {
+        this._tokenManager.removeMappings(this._mappingId!);
     }
 
     /**

--- a/packages/moxb/src/routing/location-state-space/state-space/StateSpaceHandler.ts
+++ b/packages/moxb/src/routing/location-state-space/state-space/StateSpaceHandler.ts
@@ -76,9 +76,9 @@ export interface StateSpaceHandler<LabelType, WidgetType, DataType> {
  */
 export interface StateSpaceHandlerProps<LabelType, WidgetType, DataType> {
     /**
-     * An optional ID, for debugging
+     * An ID, for debugging
      */
-    id?: string;
+    id: string;
 
     /**
      * The list of sub-states to work with

--- a/packages/moxb/src/routing/location-state-space/state-space/StateSpaceHandlerImpl.ts
+++ b/packages/moxb/src/routing/location-state-space/state-space/StateSpaceHandlerImpl.ts
@@ -1,4 +1,4 @@
-import { SubState, StateCondition, SubStateInContext } from './StateSpace';
+import { SubState, StateCondition, SubStateInContext, StateSpace } from './StateSpace';
 import { StateSpaceHandler, StateSpaceHandlerProps, FilterParams } from './StateSpaceHandler';
 import { SubStateKeyGenerator } from './SubStateKeyGenerator';
 import { SubStateKeyGeneratorImpl } from './SubStateKeyGeneratorImpl';
@@ -54,6 +54,7 @@ export class StateSpaceHandlerImpl<LabelType, WidgetType, DataType>
     protected readonly _id: string;
     protected readonly _debug?: boolean;
     protected readonly _keyGen: SubStateKeyGenerator;
+    protected readonly _subStates: StateSpace<LabelType, WidgetType, DataType>;
     public readonly _subStatesInContext: SubStateInContext<LabelType, WidgetType, DataType>[];
     protected readonly _allSubStates: SubStateInContext<LabelType, WidgetType, DataType>[];
     protected readonly _filterCondition?: StateCondition<DataType>;
@@ -97,6 +98,7 @@ export class StateSpaceHandlerImpl<LabelType, WidgetType, DataType>
         this._keyGen = keyGen || new SubStateKeyGeneratorImpl();
         this._enumerateSubStates = this._enumerateSubStates.bind(this);
         this._addContext = this._addContext.bind(this);
+        this._subStates = subStates;
         this._subStatesInContext = subStates.map(s => this._addContext([], s));
         this._allSubStates = Array.prototype.concat(...this._subStatesInContext.map(this._enumerateSubStates));
         this._filterCondition = filterCondition;

--- a/packages/moxb/src/routing/url-arg/UrlTokenImpl.ts
+++ b/packages/moxb/src/routing/url-arg/UrlTokenImpl.ts
@@ -1,5 +1,4 @@
 import { computed } from 'mobx';
-
 import { Query } from '../url-schema/UrlSchema';
 import { UpdateMethod } from '../location-manager';
 import { ParserFunc, UrlArg, UrlArgDefinition } from './UrlArg';
@@ -20,8 +19,13 @@ export class UrlTokenImpl<T> implements UrlArg<T> {
     }
 
     @computed
+    private get _currentQuery() {
+        return this._tokenManager.tokens;
+    }
+
+    @computed
     public get defined() {
-        return existsInQuery(this._tokenManager.tokens, this.key);
+        return existsInQuery(this._currentQuery, this.key);
     }
 
     // Extract the value from a given query
@@ -32,7 +36,7 @@ export class UrlTokenImpl<T> implements UrlArg<T> {
 
     @computed
     public get value() {
-        return this.getOnQuery(this._tokenManager.tokens);
+        return this.getOnQuery(this._currentQuery);
     }
 
     public getRawValue(value: T) {
@@ -63,6 +67,6 @@ export class UrlTokenImpl<T> implements UrlArg<T> {
 
     @computed
     public get rawValue() {
-        return this._tokenManager.tokens[this.key];
+        return this._currentQuery[this.key];
     }
 }


### PR DESCRIPTION
... so that it can work in all the menus, not only in the top menu.

The main idea is that instead of registering the path token mapping patterns manually with the token manager, we can just let the `LocationDependentArea` component do the registration. (That component has all the required information about the navigation context.)

Regardless of this, all the information lives in the model, except the mappings, which we load from the menu structure. 

There are no side-effects from render; we are using `componentDidMount` and `componentWillUnmount` for hooks.

The application-facing API doesn't change, except the constructor parameters of the token manager.

(Please merge #57 and #58 first, then rebase this one.)