### PR TITLE
Add pending state to actions

### DIFF
--- a/packages/antd/src/ActionAnt.tsx
+++ b/packages/antd/src/ActionAnt.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { observer } from 'mobx-react';
 import { BindAntProps, parseProps } from './BindAnt';
-import { Button } from 'antd';
+import { Button, Spin } from 'antd';
 import { ButtonSize, ButtonType, ButtonShape } from 'antd/lib/button';
 import { NativeButtonProps } from 'antd/lib/button/button';
 import { Action } from '@moxb/moxb';
@@ -11,6 +11,20 @@ export type BindActionAntProps = BindAntProps<Action> & NativeButtonProps;
 
 @observer
 export class ActionButtonAnt extends React.Component<BindActionAntProps> {
+    protected handleClick() {
+        const { operation } = parseProps(this.props, this.props.operation);
+        if (operation.pending) {
+            // console.log('Ignoring click on pending operation');
+        } else {
+            operation.fire();
+        }
+    }
+
+    constructor(props: BindActionAntProps) {
+        super(props);
+        this.handleClick = this.handleClick.bind(this);
+    }
+
     render() {
         const { operation, invisible, children, label, id, size, shape, htmlType, type, ...props } = parseProps(
             this.props,
@@ -22,7 +36,7 @@ export class ActionButtonAnt extends React.Component<BindActionAntProps> {
         return (
             <Button
                 id={id}
-                onClick={operation.fire}
+                onClick={this.handleClick}
                 {...props}
                 size={size as ButtonSize}
                 shape={shape as ButtonShape}
@@ -30,6 +44,7 @@ export class ActionButtonAnt extends React.Component<BindActionAntProps> {
                 htmlType={typeof htmlType === 'undefined' ? 'button' : htmlType}
             >
                 {children != null ? children : label}
+                {(operation as Action).pending && <Spin />}
             </Button>
         );
     }

--- a/packages/antd/src/__tests__/__snapshots__/ActionAnt.test.tsx.snap
+++ b/packages/antd/src/__tests__/__snapshots__/ActionAnt.test.tsx.snap
@@ -47,6 +47,7 @@ exports[`ActionFormButtonAnt should render a button by default 1`] = `
       "getHelp": [Function],
       "getInvisible": [Function],
       "getLabel": [Function],
+      "getPending": [Function],
       "getReadonly": [Function],
       "id": "TheId",
       "impl": Object {
@@ -102,6 +103,7 @@ exports[`ActionFormButtonAnt should render a button by default 1`] = `
         "getHelp": [Function],
         "getInvisible": [Function],
         "getLabel": [Function],
+        "getPending": [Function],
         "getReadonly": [Function],
         "id": "TheId",
         "impl": Object {

--- a/packages/moxb/src/action/Action.ts
+++ b/packages/moxb/src/action/Action.ts
@@ -2,4 +2,5 @@ import { Bind } from '../bind/Bind';
 
 export interface Action extends Bind {
     fire(): void;
+    readonly pending: boolean;
 }

--- a/packages/moxb/src/action/ActionImpl.ts
+++ b/packages/moxb/src/action/ActionImpl.ts
@@ -4,6 +4,7 @@ import { Action } from './Action';
 
 export interface ActionOptions extends BindOptions {
     fire(): void;
+    pending?: () => boolean;
 }
 
 export class ActionImpl extends BindImpl<ActionOptions> implements Action {
@@ -11,10 +12,22 @@ export class ActionImpl extends BindImpl<ActionOptions> implements Action {
         super(impl);
     }
 
+    protected getPending() {
+        return this.impl.pending ? this.impl.pending() : false;
+    }
+
+    get pending() {
+        return this.getPending();
+    }
+
     @action.bound
     fire() {
         if (this.enabled) {
-            this.impl.fire();
+            if (this.pending) {
+                console.warn(`cannot fire pending action ${this.id} '${this.label}'`);
+            } else {
+                this.impl.fire();
+            }
         } else {
             console.warn(`cannot fire disabled action ${this.id} '${this.label}'`);
         }


### PR DESCRIPTION
This changes adds a pending state to actions.

- When defining an action, one can can specify a "pending" function.
- When this "pending" function returns true
  - A button bound to this action will display a spinner
  - A button bound to this action won't be clickable.
