### PR TITLE
Add a widget for indicating process using antd steps

### DIFF
--- a/packages/antd/src/routing/MultiStepProcessAnt.tsx
+++ b/packages/antd/src/routing/MultiStepProcessAnt.tsx
@@ -1,0 +1,65 @@
+import * as React from 'react';
+import { observer } from 'mobx-react';
+import { Row, Col, Alert } from 'antd';
+import { StateSpace, MultiStepProcess } from '@moxb/moxb';
+import { LocationDependentArea, UIFragmentSpec } from '../not-antd';
+import { NavStepsAnt, StepsProps, StepStatus } from './NavStepsAnt';
+import { ActionButtonAnt } from '../ActionAnt';
+
+export interface MultiStepProcessProps<Step> {
+    id: string;
+    operation: MultiStepProcess<Step>;
+    steps: StateSpace<any, UIFragmentSpec, any>;
+}
+
+@observer
+export class MultiStepProcessAnt extends React.Component<MultiStepProcessProps<any>> {
+    getStatus(): StepStatus {
+        const { operation } = this.props;
+        const { finished, failed } = operation;
+        if (finished) {
+            return StepStatus.FINISH;
+        }
+        if (failed) {
+            return StepStatus.ERROR;
+        }
+        return StepStatus.PROCESS;
+    }
+
+    renderError() {
+        const { operation } = this.props;
+        const { errorMessage, finish } = operation;
+        return (
+            <div>
+                <Row type="flex" justify="center" style={{ marginTop: '2rem' }}>
+                    <Col span={14}>
+                        <Alert message="Error" description={errorMessage} type="error" showIcon />
+                    </Col>
+                </Row>
+                <Row>
+                    <Col>
+                        <ActionButtonAnt operation={finish} />
+                    </Col>
+                </Row>
+            </div>
+        );
+    }
+
+    render() {
+        const { operation, steps, id } = this.props;
+        const { currentStep, failed } = operation;
+        const stepProps: StepsProps = {
+            status: this.getStatus(),
+        };
+        return (
+            <div>
+                <NavStepsAnt arg={currentStep} id={id + '-steps-indicator'} subStates={steps} stepProps={stepProps} />
+                {failed ? (
+                    this.renderError()
+                ) : (
+                    <LocationDependentArea arg={currentStep} id={id + '-steps'} subStates={steps} />
+                )}
+            </div>
+        );
+    }
+}

--- a/packages/antd/src/routing/index.ts
+++ b/packages/antd/src/routing/index.ts
@@ -1,3 +1,4 @@
 export { NavMenuBarAnt } from './NavMenuBarAnt';
 export { MenuAndContentAnt } from './MenuAndContentAnt';
 export { NavStepsAnt } from './NavStepsAnt';
+export { MultiStepProcessAnt } from './MultiStepProcessAnt';

--- a/packages/moxb/src/routing/MultiStepProcess.ts
+++ b/packages/moxb/src/routing/MultiStepProcess.ts
@@ -1,0 +1,13 @@
+import { UrlArg } from './url-arg';
+import { Action } from '../action/Action';
+
+export interface MultiStepProcess<Step> {
+    readonly currentStep: UrlArg<Step>;
+
+    readonly failed: boolean;
+    readonly errorMessage?: string;
+    readonly finished: boolean;
+
+    // Navigate away
+    readonly finish: Action;
+}

--- a/packages/moxb/src/routing/index.ts
+++ b/packages/moxb/src/routing/index.ts
@@ -46,3 +46,5 @@ export { isTokenEmpty } from './tokens';
 
 export { TokenManager } from './TokenManager';
 export { TokenManagerImpl } from './TokenManagerImpl';
+
+export { MultiStepProcess } from './MultiStepProcess';


### PR DESCRIPTION
The steps are defined as a state-space.
The process is stored in an [URL]Arg.

The list of steps is shown at the top,
and the content (according to the current step)
is shown on the bottom.

We can also handle the finished and failed states.