### PR TITLE
Support for creating Actions backed by Meteor methods

### DIFF
--- a/packages/meteor/src/Bit.ts
+++ b/packages/meteor/src/Bit.ts
@@ -1,0 +1,29 @@
+import { observable, action } from 'mobx';
+
+/***
+ * Bit is a reactive, single-bit data store.
+ */
+export interface Bit {
+    readonly value: boolean;
+    set(): void;
+    reset(): void;
+}
+
+export class BitImpl implements Bit {
+    @observable
+    protected _value = false;
+
+    get value() {
+        return this._value;
+    }
+
+    @action
+    set() {
+        this._value = true;
+    }
+
+    @action
+    reset() {
+        this._value = false;
+    }
+}

--- a/packages/meteor/src/MeteorAction.ts
+++ b/packages/meteor/src/MeteorAction.ts
@@ -1,0 +1,121 @@
+import { Action, ActionImpl, ActionOptions, BindOptions, ValueOrFunction } from '@moxb/moxb';
+import { MeteorMethodControl } from './MeteorMethod';
+import { Bit, BitImpl } from './Bit';
+
+/**
+ * The main idea here is that it should be trivial to define a (moxb) Action that is backed by a Meteor method,
+ * so that we have type safety on the input and on the output side, we can't misspell the method name, and
+ * we also get automatic integration for things like indicating the pending state on buttons, etc.
+ */
+
+/**
+ * This is how we describe a Meteor method-based action
+ */
+interface MeteorActionOptions<Input, Output> extends BindOptions {
+    /**
+     * A (control object to a) Meteor method to use
+     */
+    method: MeteorMethodControl<Input, Output>;
+
+    /**
+     * Do we want to see debug output related to this action?
+     */
+    debug?: boolean;
+
+    /**
+     * The input to pass to this method (or a function to collect it)
+     */
+    input: ValueOrFunction<Input>;
+
+    /**
+     * An optional callback to call (with the current input) before actually executing the method call
+     * @param input
+     */
+    before?: (input: Input) => void;
+
+    /**
+     * Error handler to call when the method fails
+     */
+    failed: (error: Meteor.Error) => void;
+
+    /**
+     * A callback to call when the method succeeds
+     */
+    returned: (result: Output) => void;
+}
+
+/**
+ * This function will create a Meteor method-backed moxb Action based on the provided description (see above).
+ */
+export function createMeteorAction<Input, Output>(options: MeteorActionOptions<Input, Output>): Action {
+    const { method, input, before, failed, returned, debug, ...rest } = options;
+
+    const _pending: Bit = new BitImpl();
+
+    function getData(): Input {
+        if (typeof input === 'function') {
+            return (input as Function)();
+        } else {
+            return input!;
+        }
+    }
+
+    const debugLog = debug
+        ? (...stuff: any[]) => {
+              console.log('Meteor method action', '"' + options.id + '"', ':', ...stuff);
+          }
+        : () => {};
+
+    const actionOptions: ActionOptions = {
+        ...rest,
+        pending: () => _pending.value,
+        fire: () => {
+            _pending.set();
+            const data = getData();
+            if (before) {
+                before(data);
+            }
+            debugLog('Calling method', '"' + method.name + '"', 'with', data);
+            const start = Date.now();
+            method
+                .callPromise(data)
+                .then(result => {
+                    const stop = Date.now();
+                    debugLog('Returned in', stop - start, 'ms.', 'result:', result);
+                    returned(result);
+                    _pending.reset();
+                })
+                .catch(error => {
+                    const stop = Date.now();
+                    debugLog('Failed in', stop - start, 'ms.', 'error:', error);
+                    if (failed) {
+                        failed(error);
+                    }
+                    _pending.reset();
+                });
+        },
+    };
+
+    return new ActionImpl(actionOptions);
+}
+
+// Just preparation for some TS magic
+type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+
+/**
+ * We also provide a shortcut for methods with no input.
+ * In this case, we don't have to define the input function.
+ */
+type MeteorSimpleActionOptions<Output> = Omit<MeteorActionOptions<void, Output>, 'input'>;
+
+/**
+ * This function will create a Meteor method-backed moxb Action based on the provided description (see above).
+ *
+ * Use this with methods that don't require any input arguments.
+ */
+export function createMeteorSimpleAction<Output>(options: MeteorSimpleActionOptions<Output>): Action {
+    return createMeteorAction<void, Output>({
+        ...options,
+        input: () => undefined,
+    });
+}

--- a/packages/meteor/src/index.ts
+++ b/packages/meteor/src/index.ts
@@ -10,3 +10,4 @@ export * from './MeteorTableFetcherImpl';
 export * from './MethodDataFetcherImpl';
 export * from './QueryStringParser';
 export * from './MeteorMethod';
+export * from './MeteorAction';


### PR DESCRIPTION
This is a continuation of https://github.com/moxb/moxb/pull/71, so please merge that first.

The main idea here is that it should be trivial to define a (moxb) Action that is backed by a Meteor method,
so that we have type safety on the input and on the output side, we can't misspell the method name, and
we also get automatic integration for things like indicating the pending state on buttons, etc.
