### PR TITLE
Fix incorrect use of Ant radio groups

### DIFF
--- a/packages/antd/src/OneOfAnt.tsx
+++ b/packages/antd/src/OneOfAnt.tsx
@@ -16,9 +16,9 @@ export class OneOfAnt extends React.Component<BindAntProps<OneOf> & RadioProps &
             return null;
         }
         return (
-            <Radio.Group onChange={e => operation.setValue(e.target.value)} {...props}>
+            <Radio.Group onChange={e => operation.setValue(e.target.value)} {...props} value={operation.value}>
                 {operation.choices.map(opt => (
-                    <Radio key={opt.value} value={opt.value} checked={opt.value === operation.value}>
+                    <Radio key={opt.value} value={opt.value}>
                         {opt.widget ? opt.widget : opt.label}
                     </Radio>
                 ))}
@@ -50,9 +50,9 @@ export class OneOfButtonAnt extends React.Component<BindAntProps<OneOf> & RadioP
             return null;
         }
         return (
-            <Radio.Group onChange={e => operation.setValue(e.target.value)} {...props}>
+            <Radio.Group onChange={e => operation.setValue(e.target.value)} {...props} value={operation.value}>
                 {operation.choices.map(opt => (
-                    <Radio.Button key={opt.value} value={opt.value} checked={opt.value === operation.value}>
+                    <Radio.Button key={opt.value} value={opt.value}>
                         {opt.widget ? opt.widget : opt.label}
                     </Radio.Button>
                 ))}

--- a/packages/antd/src/__tests__/__snapshots__/OneOfAnt.test.tsx.snap
+++ b/packages/antd/src/__tests__/__snapshots__/OneOfAnt.test.tsx.snap
@@ -11,7 +11,6 @@ exports[`OneOfAnt should render a radio button group by default 1`] = `
   readOnly={false}
 >
   <Radio
-    checked={false}
     key="b"
     prefixCls="ant-radio"
     type="radio"
@@ -20,7 +19,6 @@ exports[`OneOfAnt should render a radio button group by default 1`] = `
     Banana
   </Radio>
   <Radio
-    checked={false}
     key="a"
     prefixCls="ant-radio"
     type="radio"
@@ -29,7 +27,6 @@ exports[`OneOfAnt should render a radio button group by default 1`] = `
     Apples
   </Radio>
   <Radio
-    checked={false}
     key="p"
     prefixCls="ant-radio"
     type="radio"


### PR DESCRIPTION
It turns out that when we define elements inside radio groups,
we are not supposed to pass in a "checked" property to these elements.

Instead, we should pass in "value" to the group itself, and then it will
calculate the checked state of the elements automatically.

We missed this earlier because the two approaches produce almost identical
behavior, expect in situations when the state changes quickly.
In those cases, specifying checked directly can lead to inconsistent
results.