### PR TITLE
make nav bar reactive

### DIFF
--- a/packages/antd/src/routing/NavMenuBarAnt.tsx
+++ b/packages/antd/src/routing/NavMenuBarAnt.tsx
@@ -1,3 +1,4 @@
+import { observable } from 'mobx';
 import * as React from 'react';
 import { Menu } from 'antd';
 import { observer, inject } from 'mobx-react';
@@ -30,19 +31,30 @@ export interface NavMenuProps<DataType>
  */
 export class NavMenuBarAnt<DataType> extends React.Component<NavMenuProps<DataType>> {
     protected readonly _id: string;
-    protected readonly _states: LocationDependentStateSpaceHandler<UIFragment, UIFragmentSpec, DataType>;
+    @observable.ref
+    protected _states: LocationDependentStateSpaceHandler<UIFragment, UIFragmentSpec, DataType>;
 
     public constructor(props: NavMenuProps<DataType>) {
         super(props);
         this._renderSubStateLink = this._renderSubStateLink.bind(this);
         this._renderSubStateGroup = this._renderSubStateGroup.bind(this);
         this._renderSubStateElement = this._renderSubStateElement.bind(this);
+        this._id = this.props.id || 'no-id';
+        this._states = this.getLocationDependantStateSpaceHandler();
+    }
+
+    private getLocationDependantStateSpaceHandler() {
         const { id, children: _children, extras, style, ...stateProps } = this.props;
-        this._id = id || 'no-id';
-        this._states = new LocationDependentStateSpaceHandlerImpl({
+
+        return new LocationDependentStateSpaceHandlerImpl({
             ...stateProps,
-            id: 'menu bar of ' + id,
+            id: 'menu bar of ' + this._id,
         });
+    }
+
+    componentDidUpdate() {
+        // to be reactive, we have to update the
+        this._states = this.getLocationDependantStateSpaceHandler();
     }
 
     // tslint:disable-next-line:cyclomatic-complexity


### PR DESCRIPTION
The problem was that `NavMenuBarAnt` kept a state and did not react properly to property changes. In particular, if something has changed in user, the `getUserMenu` is called correctly but `NavMenuBarAnt` did to react to the changes, because it created the `LocationDependentStateSpaceHandler` only in the constructor.

The problematic part of `getUserMenu` is here:

```
export const getUserMenu = (user?: User): StateSpace<UIFragment, UIFragmentSpec, PermData> => [
...
            {
                displayOnly: true,
                hidden: !user || !user!.currentOrganization,
                key: 'myOrganization',
                pathTokens: ['organizations', user ? (user.currentOrganization || { _id: '' })._id : '_', 'edit'],
                label: tr('Account.menu.actions.organization', 'Settings for {{name}}', () => ({
                    ...user!.currentOrganization,
                })),
            },
...
]
````

Every time the `user.currentOrganization` changes, `getUserMenu` must be called.

Therefore I tried two ways how to fix `NavMenuBarAnt`. 
1. In the first commit, I update the `this._states` variable
2. In the second commit I made the class stateless and therefore it is naturally reactive.

Remember: `mobx` only tracks `render`. It doe not track any other changes of the `React.Component`. Therefore a stateless implementation is the cleanest in my opinion, because there is no need to mess with state...
