### PR TITLE
Modify the "soft" navigation APIs

### DIFF
--- a/packages/moxb/src/routing/TokenManager.ts
+++ b/packages/moxb/src/routing/TokenManager.ts
@@ -1,4 +1,4 @@
-import { UpdateMethod } from './location-manager';
+import { SuccessCallback, UpdateMethod } from './location-manager';
 import { StateCondition, StateSpace } from './location-state-space/state-space/StateSpace';
 import { Query } from './url-schema/UrlSchema';
 
@@ -26,7 +26,7 @@ export interface TokenManager {
     tokens: Query;
     doSetToken(key: string, value: any, updateMethod?: UpdateMethod): void;
 
-    trySetToken(key: string, value: any, updateMethod?: UpdateMethod): Promise<boolean>;
+    trySetToken(key: string, value: any, updateMethod?: UpdateMethod, callback?: SuccessCallback): void;
 
     getURLForTokenChange(key: string, value: any): string;
 }

--- a/packages/moxb/src/routing/location-manager/LocationManager.ts
+++ b/packages/moxb/src/routing/location-manager/LocationManager.ts
@@ -2,6 +2,8 @@ import { UrlArg } from '../url-arg';
 
 import { Query } from '../url-schema/UrlSchema';
 
+export type SuccessCallback = (value: boolean) => void;
+
 /**
  * Information about a planned change in the URl arguments
  */
@@ -95,11 +97,13 @@ export interface LocationChangeInterceptor {
  * The Location Manager is responsible for tracking the location (ie. URL) of the application,
  * and abstract away the interface by providing separate path tokens and URL arguments.
  *
- * In many cases, the APIs come in pairs: there is a `doWhatever()` and a `tryWhatever()` call.
- * The `doWhatever()` call always executes the operation, while the `tryWhatever()` version
- * will first negotiate will all the registered navigation interceptors, then maybe
- * ask for a confirmation from the user, and then might (or might not) execute the change.
- * These `tryWhatever()` calls always return a `Promise<boolean>`.
+ * In many cases, the APIs come in pairs:
+ * - there is a `doWhatever()` call, which executes the operation right away,
+ * - there is a `tryWhatever()` call, which will negotiate will all the registered
+ *   navigation interceptors, then maybe ask for a confirmation from the user,
+ *   and then might (or might not) execute the change.
+ *   These second method accepts an optional callback as a final parameter,
+ *   which will be called with a boolean value, signaling whether it was executed or now.
  */
 export interface LocationManager {
     /**
@@ -158,7 +162,7 @@ export interface LocationManager {
      * @param tokens The tokens to set.
      * @param method The method to use for updating the URL.
      */
-    trySetPathTokens: (position: number, tokens: string[], method?: UpdateMethod) => Promise<boolean>;
+    trySetPathTokens: (position: number, tokens: string[], method?: UpdateMethod, callback?: SuccessCallback) => void;
 
     /**
      * Appends a set of tokens to the current path
@@ -179,12 +183,12 @@ export interface LocationManager {
      * @param tokens The tokens to append.
      * @param method The method to use for updating the URL.
      */
-    tryAppendPathTokens: (tokens: string[], method?: UpdateMethod) => Promise<boolean>;
+    tryAppendPathTokens: (tokens: string[], method?: UpdateMethod, callback?: SuccessCallback) => void;
 
     /**
      * Removes the given number of path tokens from the current path.
      */
-    tryRemovePathTokens: (count: number, method?: UpdateMethod) => Promise<boolean>;
+    tryRemovePathTokens: (count: number, method?: UpdateMethod, callback?: SuccessCallback) => void;
 
     /**
      * the search queries for the current location
@@ -212,7 +216,7 @@ export interface LocationManager {
      * @param changes The changes to execute
      * @param method The method to use for updating the URL.
      */
-    trySetQueries: (changes: QueryChange[], method?: UpdateMethod) => Promise<boolean>;
+    trySetQueries: (changes: QueryChange[], method?: UpdateMethod, callback?: SuccessCallback) => void;
 
     /**
      * Set the last few path tokens, and also some queries
@@ -241,8 +245,9 @@ export interface LocationManager {
         position: number,
         tokens: string[] | undefined,
         changes: QueryChange[] | undefined,
-        method?: UpdateMethod
-    ) => Promise<boolean>;
+        method?: UpdateMethod,
+        callback?: SuccessCallback
+    ) => void;
 
     /**
      * Determine the URL that we would get if we changed an URL argument
@@ -277,7 +282,7 @@ export interface LocationManager {
      * @param rawValue The new value to set (already in string form)
      * @param method The method to use for updating the URL.
      */
-    trySetQuery: (key: string, rawValue: string | undefined, method?: UpdateMethod) => Promise<boolean>;
+    trySetQuery: (key: string, rawValue: string | undefined, method?: UpdateMethod, success?: SuccessCallback) => void;
 
     /**
      * Register a permanent URl argument.

--- a/packages/moxb/src/routing/location-manager/index.ts
+++ b/packages/moxb/src/routing/location-manager/index.ts
@@ -1,2 +1,9 @@
-export { UpdateMethod, LocationManager, UsesLocation, QueryChange, TestLocation } from './LocationManager';
+export {
+    UpdateMethod,
+    LocationManager,
+    UsesLocation,
+    QueryChange,
+    TestLocation,
+    SuccessCallback,
+} from './LocationManager';
 export { BasicLocationManagerImpl } from './BasicLocationManagerImpl';

--- a/packages/moxb/src/routing/location-state-space/LocationDependentStateSpaceHandler.ts
+++ b/packages/moxb/src/routing/location-state-space/LocationDependentStateSpaceHandler.ts
@@ -1,4 +1,4 @@
-import { UsesLocation } from '../location-manager';
+import { SuccessCallback, UpdateMethod, UsesLocation } from '../location-manager';
 import { Navigable } from '../navigable';
 import { UsesTokenManager } from '../TokenManager';
 import { UrlArg } from '../url-arg';
@@ -79,7 +79,11 @@ export interface LocationDependentStateSpaceHandler<LabelType, WidgetType, DataT
     /**
      * Gracefully attempt to change the location so that the given SubState becomes active.
      */
-    trySelectSubState(state: SubStateInContext<LabelType, WidgetType, DataType>): Promise<boolean>;
+    trySelectSubState(
+        state: SubStateInContext<LabelType, WidgetType, DataType>,
+        method?: UpdateMethod,
+        callback?: SuccessCallback
+    ): void;
 
     /**
      * Change the location so that the SubState with the given key becomes active.

--- a/packages/moxb/src/routing/location-state-space/LocationDependentStateSpaceHandlerImpl.ts
+++ b/packages/moxb/src/routing/location-state-space/LocationDependentStateSpaceHandlerImpl.ts
@@ -1,4 +1,4 @@
-import { LocationManager, UpdateMethod } from '../location-manager';
+import { LocationManager, SuccessCallback, UpdateMethod } from '../location-manager';
 import { TokenManager } from '../TokenManager';
 import { updateTokenString } from '../tokens';
 import { AnyUrlArgImpl, UrlArg, URLARG_TYPE_ORDERED_STRING_ARRAY } from '../url-arg';
@@ -94,8 +94,8 @@ export class LocationDependentStateSpaceHandlerImpl<LabelType, WidgetType, DataT
                       doSet(value) {
                           arg!.doSet(value);
                       },
-                      trySet(value) {
-                          return arg!.trySet(value);
+                      trySet(value, callback?: SuccessCallback) {
+                          arg!.trySet(value, undefined, callback);
                       },
                       getModifiedUrl(value: string) {
                           return arg.getModifiedUrl(value);
@@ -218,13 +218,17 @@ export class LocationDependentStateSpaceHandlerImpl<LabelType, WidgetType, DataT
         }
     }
 
-    public trySelectSubState(state: SubStateInContext<LabelType, WidgetType, DataType>, method?: UpdateMethod) {
+    public trySelectSubState(
+        state: SubStateInContext<LabelType, WidgetType, DataType>,
+        method?: UpdateMethod,
+        callback?: SuccessCallback
+    ) {
         const { totalPathTokens } = state;
         if (this._urlArg) {
             const value = this._getArgValueForSubState(state);
-            return this._urlArg.trySet(value);
+            return this._urlArg.trySet(value, method, callback);
         } else {
-            return this._locationManager.trySetPathTokens(this._parsedTokens, totalPathTokens, method);
+            this._locationManager.trySetPathTokens(this._parsedTokens, totalPathTokens, method, callback);
         }
     }
 

--- a/packages/moxb/src/routing/location-state-space/__tests__/LocationDependentStateSpaceHandlerImpl.test.ts
+++ b/packages/moxb/src/routing/location-state-space/__tests__/LocationDependentStateSpaceHandlerImpl.test.ts
@@ -174,7 +174,7 @@ describe('Location-Dependent State-Space-Handler implementation, powered by url 
         fakeHistory.push('/');
         await when(() => !locationManager.query.where);
         fakeHistory.push('/?where=unicorn');
-        await when(() => !locationManager.query.where);
+        await when(() => !!locationManager.query.where);
         expect(handler.getActiveSubState()).toBeNull();
     });
 

--- a/packages/moxb/src/routing/url-arg/AnyUrlArgImpl.ts
+++ b/packages/moxb/src/routing/url-arg/AnyUrlArgImpl.ts
@@ -1,13 +1,13 @@
 import { computed } from 'mobx';
 
 import { ParserFunc, UrlArg, UrlArgDefinition } from './UrlArg';
-import { TestLocation } from '../location-manager/LocationManager';
+import { SuccessCallback, TestLocation, UpdateMethod } from '../location-manager/LocationManager';
 
 export interface UrlArgBackend {
     readonly rawValue: string | undefined;
     rawValueOn(location: TestLocation | undefined): string | undefined;
     doSet: (value: string) => void;
-    trySet: (value: string) => Promise<boolean>;
+    trySet: (value: string, callback?: SuccessCallback) => void;
     getModifiedUrl?: (value: string) => string | undefined;
 }
 
@@ -73,12 +73,12 @@ export class AnyUrlArgImpl<T> implements UrlArg<T> {
         this.doSet(this._def.defaultValue);
     }
 
-    public trySet(value: T): Promise<boolean> {
-        return this.backend.trySet(this.getRawValue(value));
+    public trySet(value: T, _method?: UpdateMethod, callback?: SuccessCallback) {
+        this.backend.trySet(this.getRawValue(value), callback);
     }
 
-    public tryReset() {
-        return this.trySet(this._def.defaultValue);
+    public tryReset(method?: UpdateMethod, callback?: SuccessCallback) {
+        this.trySet(this._def.defaultValue, method, callback);
     }
 
     @computed

--- a/packages/moxb/src/routing/url-arg/InMemoryArgImpl.ts
+++ b/packages/moxb/src/routing/url-arg/InMemoryArgImpl.ts
@@ -1,7 +1,7 @@
 import { observable } from 'mobx';
 import { AnyUrlArgImpl, UrlArgBackend } from './AnyUrlArgImpl';
 import { UrlArg, UrlArgDefinition } from './UrlArg';
-import { TestLocation } from '../location-manager/LocationManager';
+import { SuccessCallback, TestLocation } from '../location-manager/LocationManager';
 
 class MiniStore implements UrlArgBackend {
     @observable
@@ -15,9 +15,11 @@ class MiniStore implements UrlArgBackend {
         this.raw = value;
     }
 
-    trySet(value: string | undefined): Promise<boolean> {
+    trySet(value?: string, callback?: SuccessCallback): void {
         this.raw = value;
-        return Promise.resolve(true);
+        if (callback) {
+            callback(true);
+        }
     }
 
     set rawValue(value: string | undefined) {

--- a/packages/moxb/src/routing/url-arg/UrlArg.ts
+++ b/packages/moxb/src/routing/url-arg/UrlArg.ts
@@ -1,4 +1,4 @@
-import { UpdateMethod } from '../location-manager';
+import { SuccessCallback, UpdateMethod } from '../location-manager';
 import { TestLocation } from '../location-manager/LocationManager';
 
 export interface ParserFunc<T> {
@@ -61,8 +61,9 @@ export interface UrlArg<T> {
      *
      * @param value The new value
      * @param method The method for updating the URL (push or replace)
+     * @param callback Callback to call with the result status
      */
-    trySet(value: T, method?: UpdateMethod): Promise<boolean>;
+    trySet(value: T, method?: UpdateMethod, callback?: SuccessCallback): void;
 
     /**
      * Reset the value to default
@@ -75,8 +76,9 @@ export interface UrlArg<T> {
      * Reset the value to default
      *
      * @param method The method for updating the URL (push or replace)
+     * @param callback Callback to call with the result status
      */
-    tryReset(method?: UpdateMethod): Promise<boolean>;
+    tryReset(method?: UpdateMethod, callback?: SuccessCallback): void;
 
     /**
      * Get the URL string that would result if we modified the value

--- a/packages/moxb/src/routing/url-arg/UrlArgImpl.ts
+++ b/packages/moxb/src/routing/url-arg/UrlArgImpl.ts
@@ -1,5 +1,5 @@
 import { computed } from 'mobx';
-import { LocationManager, QueryChange, UpdateMethod } from '../location-manager';
+import { LocationManager, QueryChange, SuccessCallback, UpdateMethod } from '../location-manager';
 
 import { Query } from '../url-schema/UrlSchema';
 import { ArgChange, ParserFunc, UrlArg, UrlArgDefinition } from './UrlArg';
@@ -68,17 +68,17 @@ export class UrlArgImpl<T> implements UrlArg<T> {
         this._locationManager.doSetQuery(this.key, rawValue, method);
     }
 
-    public trySet(value: T, method?: UpdateMethod): Promise<boolean> {
+    public trySet(value: T, method?: UpdateMethod, callback?: SuccessCallback) {
         const rawValue = this.getRawValue(value);
-        return this._locationManager.trySetQuery(this.key, rawValue, method);
+        this._locationManager.trySetQuery(this.key, rawValue, method, callback);
     }
 
     public doReset(method?: UpdateMethod) {
         this.doSet(this._def.defaultValue, method);
     }
 
-    public tryReset(method?: UpdateMethod): Promise<boolean> {
-        return this.trySet(this._def.defaultValue, method);
+    public tryReset(method?: UpdateMethod, callback?: SuccessCallback) {
+        this.trySet(this._def.defaultValue, method, callback);
     }
 
     @computed

--- a/packages/moxb/src/routing/url-arg/UrlTokenImpl.ts
+++ b/packages/moxb/src/routing/url-arg/UrlTokenImpl.ts
@@ -1,5 +1,5 @@
 import { computed } from 'mobx';
-import { UpdateMethod } from '../location-manager';
+import { SuccessCallback, UpdateMethod } from '../location-manager';
 import { TokenManager } from '../TokenManager';
 import { Query } from '../url-schema/UrlSchema';
 import { ParserFunc, UrlArg, UrlArgDefinition } from './UrlArg';
@@ -66,13 +66,13 @@ export class UrlTokenImpl<T> implements UrlArg<T> {
         this.doSet(this._def.defaultValue, method);
     }
 
-    public trySet(value: T, method?: UpdateMethod) {
+    public trySet(value: T, method?: UpdateMethod, callback?: SuccessCallback) {
         const rawValue = this.getRawValue(value);
-        return this._tokenManager.trySetToken(this.key, rawValue, method);
+        this._tokenManager.trySetToken(this.key, rawValue, method, callback);
     }
 
-    public tryReset(method?: UpdateMethod) {
-        return this.trySet(this._def.defaultValue, method);
+    public tryReset(method?: UpdateMethod, callback?: SuccessCallback) {
+        this.trySet(this._def.defaultValue, method, callback);
     }
 
     @computed


### PR DESCRIPTION
... to accept (optional) callbacks instead of returning
Promises (which can optionally be used), since tslint
really _hates_ the lying over left-over promises.

This is a fully internal refactoring, no features have been added or changed.