### PR TITLE
Fix: do not report errors more than once

### DIFF
--- a/packages/moxb/src/bind/BindImpl.ts
+++ b/packages/moxb/src/bind/BindImpl.ts
@@ -204,7 +204,7 @@ export class BindImpl<Options extends BindOptions<CustomData>, CustomData = unde
     @computed
     get error() {
         if (this.hasErrors) {
-            return (this.getErrors() as string[]).join(' ');
+            return this.getErrors().join(' ');
         } else {
             return undefined;
         }
@@ -222,12 +222,10 @@ export class BindImpl<Options extends BindOptions<CustomData>, CustomData = unde
             this._errors!.push(error!);
         }
     }
-    protected getErrors() {
-        if (this.impl.getErrors) {
-            return this.impl.getErrors();
-        } else {
-            return this._errors;
-        }
+    protected getErrors(): string[] {
+        const errors = (this.impl.getErrors && this.impl.getErrors()) || [];
+        // Set keeps the items in insertion order
+        return Array.from(new Set([...errors, ...(this._errors || [])]));
     }
 
     @action.bound

--- a/packages/moxb/src/bind/__tests__/BindImpl.test.ts
+++ b/packages/moxb/src/bind/__tests__/BindImpl.test.ts
@@ -459,6 +459,41 @@ describe('interface Bind', function() {
             expect(bind.hasErrors).toEqual(true);
         });
 
+        it('should not show duplicates when getError returns multiple errors', function() {
+            const bind: Bind = newBind({
+                id: 'test',
+                getErrors: jest.fn().mockReturnValue(['Error 1', 'Error 1', 'Error 2', 'Error 1']),
+            });
+            expect(bind.errors).toEqual(['Error 1', 'Error 2']);
+            expect(bind.hasErrors).toEqual(true);
+        });
+
+        it('should not show duplicates when multiple setError is called', function() {
+            const bind: Bind = newBind({
+                id: 'test',
+            });
+            bind.setError('Error 1');
+            bind.setError('Error 2');
+            bind.setError('Error 1');
+            expect(bind.errors).toEqual(['Error 1', 'Error 2']);
+            expect(bind.hasErrors).toEqual(true);
+        });
+
+        it('should not show duplicates when multiple setError is called and getErrors returns errors', function() {
+            const bind: Bind = newBind({
+                id: 'test',
+                getErrors: jest
+                    .fn()
+                    .mockReturnValue(['Error 1', 'Error 1', 'Error 2', 'Error 1', 'Only Function Error']),
+            });
+            bind.setError('Error 1');
+            bind.setError('Error 2');
+            bind.setError('Error 1');
+            bind.setError('Set Error 1');
+            expect(bind.errors).toEqual(['Error 1', 'Error 2', 'Only Function Error', 'Set Error 1']);
+            expect(bind.hasErrors).toEqual(true);
+        });
+
         it('should have the BindImpl as `this`', function() {
             let theThis: any = undefined;
             const getErrors = jest.fn().mockImplementation(function(this: any) {

--- a/packages/moxb/src/form/FormImpl.ts
+++ b/packages/moxb/src/form/FormImpl.ts
@@ -58,16 +58,17 @@ export class FormImpl extends BindImpl<FormOptions> implements Form {
     @computed
     get allErrors(): string[] {
         const valuesWithErrors = this.values.filter(v => !!v.errors);
-        const allErrors: string[] = [];
+        // Set keeps the items in insertion order
+        const allErrors = new Set<string>();
         valuesWithErrors.forEach(v => {
             v.errors!.forEach(error => {
-                allErrors.push(v.label ? v.label + ': ' + t(error, error) : t(error, error));
+                allErrors.add(v.label ? v.label + ': ' + t(error, error) : t(error, error));
             });
         });
         this.errors!.forEach(error => {
-            allErrors.push(this.label ? this.label + ': ' + t(error, error) : t(error, error));
+            allErrors.add(this.label ? this.label + ': ' + t(error, error) : t(error, error));
         });
-        return allErrors;
+        return Array.from(allErrors);
     }
 
     @computed

--- a/packages/moxb/src/form/__tests__/Form.test.ts
+++ b/packages/moxb/src/form/__tests__/Form.test.ts
@@ -104,6 +104,29 @@ describe('Form', function() {
             bindNoPass.setError('bar');
             expect(bindForm.allErrors).toEqual(['foo', 'doo', 'bar']);
         });
+        it('should return an array with all occurred errors without duplicates', function() {
+            bindText.clearErrors();
+            bindPass.clearErrors();
+            const bindNoText = new TextImpl({
+                id: 'textNoLabel',
+                onSave: onSaveUserText,
+                initialValue: () => 'foo',
+            });
+            const bindNoPass = new TextImpl({
+                id: 'passwordNoLAbel',
+                onSave: onSavePasswordText,
+            });
+            bindForm = new FormImpl({
+                id: 'Impl.testForm',
+                values: [bindNoText, bindNoPass],
+            });
+            bindNoText.setError('foo');
+            bindNoText.setError('doo');
+            bindNoPass.setError('bar');
+            bindNoPass.setError('foo');
+            bindNoText.setError('doo');
+            expect(bindForm.allErrors).toEqual(['foo', 'doo', 'bar']);
+        });
     });
 
     describe('hasErrors', function() {


### PR DESCRIPTION
There was a problem that same error string appeared multiple times in the UI.