### PR TITLE
[VS-175] Eliminate duplicate change interceptors

### DIFF
--- a/packages/antd/src/not-antd/rootOrDetails.tsx
+++ b/packages/antd/src/not-antd/rootOrDetails.tsx
@@ -1,3 +1,4 @@
+const uuidv4 = require('uuid/v4');
 import {
     getNextPathToken,
     isTokenEmpty,
@@ -26,6 +27,7 @@ export interface DetailProps {
 }
 
 export function rootOrDetails<DataType>(ownProps: OwnProps<DataType>) {
+    const nodeId = uuidv4();
     return inject('locationManager')(
         observer((props: ComponentProps<DataType>) => {
             let rootHooks: NavStateHooks | undefined;
@@ -42,6 +44,10 @@ export function rootOrDetails<DataType>(ownProps: OwnProps<DataType>) {
              * from the user.
              */
             props.locationManager!.registerChangeInterceptor({
+                getId() {
+                    return nodeId;
+                },
+
                 /**
                  * This is our "change interceptor" hook, that will be called by the
                  * `LocationManager`.

--- a/packages/moxb/src/routing/location-manager/BasicLocationManagerImpl.ts
+++ b/packages/moxb/src/routing/location-manager/BasicLocationManagerImpl.ts
@@ -68,9 +68,15 @@ export class BasicLocationManagerImpl implements LocationManager {
      * Register a new interceptor that we have to talk to before executing a navigation change.
      */
     registerChangeInterceptor(interceptor: LocationChangeInterceptor) {
-        if (this._interceptors.indexOf(interceptor) === -1) {
+        const newId = interceptor.getId();
+        const index = this._interceptors.findIndex(i => i.getId() === newId);
+        if (index === -1) {
             // We don't want to add anyone twice.
             this._interceptors.push(interceptor);
+            // console.log('Added new interceptor', newId);
+        } else {
+            this._interceptors[index] = interceptor;
+            // console.log('Updated interceptor', newId);
         }
     }
 

--- a/packages/moxb/src/routing/location-manager/LocationManager.ts
+++ b/packages/moxb/src/routing/location-manager/LocationManager.ts
@@ -85,6 +85,12 @@ export interface TestLocation {
  */
 export interface LocationChangeInterceptor {
     /**
+     * Each location change interceptor should be able to return a unique ID.
+     * This ID is used to recognize newer iterations of the same component.
+     */
+    getId(): string;
+
+    /**
      * This hook will be called before any "soft" navigation change event can succeed,
      * in order to collect any confirmation questions that must be presented to the user.
      *

--- a/packages/moxb/src/routing/location-state-space/LocationDependentStateSpaceHandlerImpl.ts
+++ b/packages/moxb/src/routing/location-state-space/LocationDependentStateSpaceHandlerImpl.ts
@@ -25,6 +25,10 @@ export class LocationDependentStateSpaceHandlerImpl<LabelType, WidgetType, DataT
     protected readonly _parsedTokens: number;
     protected _mappingId?: string;
 
+    getId() {
+        return this._id;
+    }
+
     /**
      * This is our "change interceptor" hook, that will be called by the LocationManager.
      */


### PR DESCRIPTION
... which has sneaked into the system when we started to
dynamically re-create the state space handlers.

Now each change interceptor must be able to produce a unique ID
for the component that it is representing, and newer iterations
of the same interceptor replace the old one's registration, instead
of being added at the end of the list.

This make sure that we always have only one interceptor from
each kind, and thus eliminates the duplicated questions.