### PR TITLE
Improve meteor subscriptions API

### DIFF
--- a/packages/meteor/src/MeteorSubscription.ts
+++ b/packages/meteor/src/MeteorSubscription.ts
@@ -1,13 +1,31 @@
 export interface MeteorSubscription {
+    /** @deprecated since version v0.2.0-beta.18 */
+    readonly isSubscriptionReady: boolean;
+
     /**
+     * Is this subscription still pending?
+     *
      * **Note**: This must be checked in the render function, else
      * the auto subscription mechanism does not work!
      *
      * Background: we use mobx onBecomeObserved on this attribute to subscribe to the meteor subscription.
      */
-    readonly isSubscriptionReady: boolean;
-    readonly hasFailed: boolean;
-    readonly error?: any;
-
     readonly pending: boolean;
+
+    /**
+     * Has this subscription failed?
+     *
+     * If yes, there should be some errors, and an error message, too
+     */
+    readonly hasFailed: boolean;
+
+    /**
+     * Any errors encountered
+     */
+    readonly errors: any[];
+
+    /**
+     * Errors formatted as user-readable strings
+     */
+    readonly errorMessage?: string;
 }


### PR DESCRIPTION
 - Add an `errorMessage` field, for human-readable messages
 - Rename `error` to `errors`, for capturing multiple errors.
 - Remove the `isSubscriptionReady` field, since we should use
   `pending` instead (which also checks for errors)