### PR TITLE
Expand the Value and Form API

### DIFF
--- a/packages/moxb/src/form/Form.ts
+++ b/packages/moxb/src/form/Form.ts
@@ -17,6 +17,11 @@ export interface Form extends Bind {
     hasChanges: boolean;
 
     /**
+     * Does the form has a required field that is not filled out?
+     */
+    hasMissingRequired: boolean;
+
+    /**
      * Contains the list of tracked errors by the children components
      */
     allErrors: string[];

--- a/packages/moxb/src/form/FormImpl.ts
+++ b/packages/moxb/src/form/FormImpl.ts
@@ -81,6 +81,11 @@ export class FormImpl extends BindImpl<FormOptions> implements Form {
         return !this.values.every(v => (v.isInitialValue === undefined ? true : v.isInitialValue));
     }
 
+    @computed
+    get hasMissingRequired() {
+        return !this.values.filter(v => v.required).every(v => v.isGiven);
+    }
+
     @action.bound
     onSubmitForm(evt?: any) {
         if (!this.impl.doSubmitRefresh && evt) {

--- a/packages/moxb/src/form/__tests__/Form.test.ts
+++ b/packages/moxb/src/form/__tests__/Form.test.ts
@@ -8,6 +8,8 @@ describe('Form', function() {
     const bindText = new TextImpl({
         id: 'text',
         label: 'text',
+        required: true,
+        isGiven: value => !!value && value !== 'magic',
         onSave: onSaveUserText,
         initialValue: () => 'foo',
     });
@@ -156,6 +158,32 @@ describe('Form', function() {
             });
             bindForm.setError('foo');
             expect(bindForm.hasErrors).toEqual(true);
+        });
+    });
+
+    describe('hasMissingRequired', function() {
+        it('should return true if we have missing required fields', function() {
+            bindForm = new FormImpl({
+                id: 'Impl.testForm',
+                values: [bindText, bindPass],
+            });
+            bindText.setValue('');
+            expect(bindForm.hasMissingRequired).toBeTruthy();
+            bindText.setValue('apple');
+            expect(bindForm.hasMissingRequired).toBeFalsy();
+        });
+
+        it('should consider the configured isGiven function', function() {
+            bindForm = new FormImpl({
+                id: 'Impl.testForm',
+                values: [bindText, bindPass],
+            });
+            bindText.setValue('');
+            expect(bindForm.hasMissingRequired).toBeTruthy();
+            bindText.setValue('magic'); // According to the definition of bindText, this string doesn't count.
+            expect(bindForm.hasMissingRequired).toBeTruthy();
+            bindText.setValue('apple');
+            expect(bindForm.hasMissingRequired).toBeFalsy();
         });
     });
 

--- a/packages/moxb/src/value/Value.ts
+++ b/packages/moxb/src/value/Value.ts
@@ -8,6 +8,7 @@ export interface Value<T> extends Bind {
     readonly value?: T;
     readonly placeholder?: string;
     readonly required?: boolean;
+    readonly isGiven: boolean;
 
     /**
      * If the value is same as he initial value.

--- a/packages/moxb/src/value/__tests__/ValueImplTest.test.ts
+++ b/packages/moxb/src/value/__tests__/ValueImplTest.test.ts
@@ -12,10 +12,12 @@ function valueImplTestTest<T>(newBindValue: (opts: ValueOptions<ValueImplForTest
     function bindStringValue(opts: ValueOptions<ValueImplForTest<string>, string>): Value<string> {
         return new ValueImplForTest(opts);
     }
-    function bindStringValueOrNull(opts: ValueOptions<ValueImplForTest<string>, string | null>): Value<string | null> {
+    function bindStringValueOrNull(
+        opts: ValueOptions<ValueImplForTest<string | null>, string | null>
+    ): Value<string | null> {
         return new ValueImplForTest(opts);
     }
-    describe('interfce Value', function() {
+    describe('interface Value', function() {
         describe('placeholder', function() {
             beforeEach(function() {
                 setTFunction(translateKeysDefault);
@@ -158,6 +160,30 @@ function valueImplTestTest<T>(newBindValue: (opts: ValueOptions<ValueImplForTest
                     });
                     bind.value;
                     expect(theThis).toBe(bind);
+                });
+            });
+
+            describe('isGiven()', function() {
+                it('by default, it should simply look for a true-ish value', function() {
+                    const bind: Value<string> = bindStringValue({
+                        id: 'test',
+                        initialValue: () => 'foo',
+                    });
+                    expect(bind.isGiven).toBeTruthy();
+                    bind.setValue('');
+                    expect(bind.value).toBeFalsy();
+                });
+
+                it('should be able to recognize special cases, as per configuration', function() {
+                    const bind: Value<string> = bindStringValue({
+                        id: 'test',
+                        isGiven: value => !!value && value !== 'foo',
+                    });
+                    expect(bind.isGiven).toBeFalsy();
+                    bind.setValue('foo');
+                    expect(bind.isGiven).toBeFalsy();
+                    bind.setValue('bar');
+                    expect(bind.isGiven).toBeTruthy();
                 });
             });
 


### PR DESCRIPTION
 - Introducing a new optional configuration option for values: `isGiven`.
   When configured, this function will be called to test whether or not
   the current value is considered to be a real value.
 - Introducing the `isGiven` value on the `Value` interface. This will be true
   if the value has a valid value. By default, this means !!value,
   but this can be overridden by configuring the `isGiven` function,
   as mentioned above
 - Introducing the `hasMissingRequired` field on the `Form` interface.
   This will be true if some required fields are missing.
 - Change the behavior of form: when trying to save, earlier we detected
   missing required values by comparing initial values with the initial values.
   This was wrong in the cases when there was a non-null initial value.
   Now we are always using the new `isGiven` field for detecting missing values.
 - Add tests for all above