### PR TITLE
Separate the decision-related code into a new module

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,8 @@ Follow the principles in [keepachangelog.com](https://keepachangelog.com)!
 
 ### Changed
 
+* Separated the decision-related code (from binding) into a new module, so that it can be more easily reused by other components. 
+
 ### Fixed
 
 * If the `Makefile`, any file in `admin/makefiles` or the `tsconfig.json` or `package-lock.json` changes,

--- a/packages/moxb/src/bind/BindImpl.ts
+++ b/packages/moxb/src/bind/BindImpl.ts
@@ -3,6 +3,7 @@ import { t } from '../i18n/i18n';
 import { bindAllTo } from '../util/bindAllTo';
 import { idToDomId } from '../util/idToDomId';
 import { Bind } from './Bind';
+import { AnyDecision, readDecision, readReason } from '../decision';
 
 export type ValueOrFunction<T> = T | (() => T | undefined) | undefined;
 
@@ -18,24 +19,6 @@ export function getValueOrFunction<T>(value: ValueOrFunction<T>): T | undefined 
 export type StringOrFunction = ValueOrFunction<string>;
 export function getValueFromStringOrFunction(value: StringOrFunction): string | undefined {
     return getValueOrFunction(value);
-}
-
-export interface Decision {
-    allowed: boolean;
-    reason?: string;
-}
-
-export const decideAccept = (reason?: string): Decision => ({ allowed: true, reason });
-export const decideRefuse = (reason?: string): Decision => ({ allowed: false, reason });
-
-export type AnyDecision = boolean | Decision;
-
-export function readDecision(decision: AnyDecision): boolean {
-    return decision === null ? false : typeof decision === 'object' ? (decision as Decision).allowed : !!decision;
-}
-
-export function readReason(decision: AnyDecision): string | undefined {
-    return decision === null ? undefined : typeof decision === 'object' ? (decision as Decision).reason : undefined;
 }
 
 /**

--- a/packages/moxb/src/bind/__tests__/BindImpl.test.ts
+++ b/packages/moxb/src/bind/__tests__/BindImpl.test.ts
@@ -1,6 +1,7 @@
 import { setTFunction, t, translateKeysDefault, translateKeysOnly } from '../../i18n/i18n';
 import { Bind } from '../Bind';
-import { BindImpl, BindOptions, decideRefuse, getValueFromStringOrFunction } from '../BindImpl';
+import { BindImpl, BindOptions, getValueFromStringOrFunction } from '../BindImpl';
+import { decideRefuse } from '../../decision';
 
 describe('interface Bind', function() {
     function newBind(options: BindOptions) {

--- a/packages/moxb/src/decision/index.ts
+++ b/packages/moxb/src/decision/index.ts
@@ -1,0 +1,17 @@
+export interface Decision {
+    allowed: boolean;
+    reason?: string;
+}
+
+export const decideAccept = (reason?: string): Decision => ({ allowed: true, reason });
+export const decideRefuse = (reason?: string): Decision => ({ allowed: false, reason });
+
+export type AnyDecision = boolean | Decision;
+
+export function readDecision(decision: AnyDecision): boolean {
+    return decision === null ? false : typeof decision === 'object' ? (decision as Decision).allowed : !!decision;
+}
+
+export function readReason(decision: AnyDecision): string | undefined {
+    return decision === null ? undefined : typeof decision === 'object' ? (decision as Decision).reason : undefined;
+}

--- a/packages/moxb/src/index.ts
+++ b/packages/moxb/src/index.ts
@@ -1,3 +1,4 @@
 export * from './impl';
 export * from './types';
 export * from './routing';
+export * from './decision';

--- a/packages/moxb/src/keyboard-shortcuts/KeyboardShortcutsManagerImpl.ts
+++ b/packages/moxb/src/keyboard-shortcuts/KeyboardShortcutsManagerImpl.ts
@@ -1,8 +1,9 @@
 import { action as mobxAction, computed, observable } from 'mobx';
-import { AnyDecision, readDecision, StringOrFunction } from '../bind/BindImpl';
+import { StringOrFunction } from '../bind/BindImpl';
 import { t } from '../i18n/i18n';
 
 import { KeyboardAction, KeyboardShortcutGroup, KeyboardShortcutsManager } from './KeyboardShortcutsManager';
+import { AnyDecision, readDecision } from '../decision';
 
 export interface KeyboardShortGroupOptions {
     readonly id: string;


### PR DESCRIPTION
... so that it can be more easily reused by other components.

There is no new code, this is purely moving some code around.
