### PR TITLE
Support for passing on class names for submenus

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,7 @@ Follow the principles in [keepachangelog.com](https://keepachangelog.com)!
 * Added the original onSubmit form event to the form operation, so the event handling can be done in a callback.
 * Added support for easily adding separators in submenus
 * Menu items now get IDs, for easier testing
+* Added support for passing on class names for submenus
 
 ### Changed
 

--- a/packages/antd/src/routing/NavMenuBarAnt.tsx
+++ b/packages/antd/src/routing/NavMenuBarAnt.tsx
@@ -87,12 +87,17 @@ export class NavMenuBarAnt<DataType> extends React.Component<NavMenuProps<DataTy
         states: LocationDependentStateSpaceHandler<UIFragment, UIFragmentSpec, DataType>,
         state: SubStateInContext<UIFragment, UIFragmentSpec, DataType>
     ) {
-        const { label, key, subStates, flat, menuKey, linkStyle } = state;
+        const { label, key, subStates, flat, menuKey, linkStyle, itemClassName } = state;
         if (!flat && !key) {
             throw new Error("Can't create a hierarchical menu group without a key!");
         }
         return (
-            <Menu.SubMenu key={menuKey} title={renderUIFragment(label || key || '***')} style={linkStyle}>
+            <Menu.SubMenu
+                key={menuKey}
+                className={itemClassName}
+                title={renderUIFragment(label || key || '***')}
+                style={linkStyle}
+            >
                 {subStates!.map(s => this.renderSubStateElement(states, s))}
             </Menu.SubMenu>
         );


### PR DESCRIPTION
This is a trivial change, just passing on a parameter that is already being passed on at other places.