### PR TITLE
Fix placeholder text display

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -24,6 +24,7 @@ Follow the principles in [keepachangelog.com](https://keepachangelog.com)!
   
 ### Fixed
 
+* Fix placeholder text display for OneOfSelect and ManyOfSelect ant design components
 * If the `Makefile`, any file in `admin/makefiles` or the `tsconfig.json` or `package-lock.json` changes,
   we have to re-run `tsc`
 * Fixed error handling for form errors, e.g. errors from callbacks.

--- a/packages/antd/src/ManyOfAnt.tsx
+++ b/packages/antd/src/ManyOfAnt.tsx
@@ -11,7 +11,7 @@ import { BindFormItemAntProps, FormItemAnt, parsePropsForChild } from './FormIte
 @observer
 export class ManyOfAnt extends React.Component<BindAntProps<ManyOf> & SelectProps> {
     render() {
-        const { operation, invisible, mode, children, defaultValue, placeholder, ...props } = parseProps(
+        const { operation, invisible, mode, children, defaultValue, ...props } = parseProps(
             this.props,
             this.props.operation
         );
@@ -23,8 +23,8 @@ export class ManyOfAnt extends React.Component<BindAntProps<ManyOf> & SelectProp
         return (
             <Select
                 onChange={(selectionValue: any) => operation.setValue(selectionValue)}
-                value={value}
-                placeholder={placeholder}
+                value={value || undefined}
+                placeholder={operation.placeholder}
                 defaultValue={defaultValue}
                 mode={typeof mode === 'undefined' ? 'default' : mode}
                 {...props}

--- a/packages/antd/src/OneOfAnt.tsx
+++ b/packages/antd/src/OneOfAnt.tsx
@@ -81,18 +81,15 @@ export class OneOfButtonFormAnt extends React.Component<
 @observer
 export class OneOfSelectAnt extends React.Component<BindAntProps<OneOf> & SelectProps> {
     render() {
-        const { operation, invisible, value, placeholder, mode, ...props } = parseProps(
-            this.props,
-            this.props.operation
-        );
+        const { operation, invisible, mode, ...props } = parseProps(this.props, this.props.operation);
         if (invisible) {
             return null;
         }
         return (
             <Select
                 onChange={(selectionValue: any) => operation.setValue(selectionValue)}
-                value={this.props.operation.value || ''}
-                placeholder={placeholder}
+                value={operation.value || undefined}
+                placeholder={operation.placeholder}
                 mode={mode || 'default'}
                 {...props}
             >

--- a/packages/antd/src/__tests__/__snapshots__/ManyOfAnt.test.tsx.snap
+++ b/packages/antd/src/__tests__/__snapshots__/ManyOfAnt.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`ManyOfAnt should render a select control by default 1`] = `
   label="Choose your snack"
   mode="default"
   onChange={[Function]}
+  placeholder="Please select"
   readOnly={false}
   showSearch={false}
   transitionName="slide-up"

--- a/packages/antd/src/__tests__/__snapshots__/OneOfAnt.test.tsx.snap
+++ b/packages/antd/src/__tests__/__snapshots__/OneOfAnt.test.tsx.snap
@@ -67,10 +67,10 @@ exports[`OneOfSelectAnt should render a select control by default 1`] = `
   label="Select one of"
   mode="default"
   onChange={[Function]}
+  placeholder="..."
   readOnly={false}
   showSearch={false}
   transitionName="slide-up"
-  value=""
 >
   <Option
     key="b"


### PR DESCRIPTION
There was a problem with displaying the placeholder text correctly in OneOfSelect and ManyOfSelect ant design components.

Fixes: [https://goessntl.atlassian.net/browse/VS-238](https://goessntl.atlassian.net/browse/VS-238)