### PR TITLE
OneOf improvements

### DIFF
--- a/packages/antd/src/OneOfAnt.tsx
+++ b/packages/antd/src/OneOfAnt.tsx
@@ -45,9 +45,12 @@ export class OneOfFormAnt extends React.Component<BindAntProps<OneOf> & RadioPro
 @observer
 export class OneOfButtonAnt extends React.Component<BindAntProps<OneOf> & RadioProps & RadioGroupProps> {
     render() {
-        const { operation, invisible, ...props } = parseProps(this.props, this.props.operation);
+        const { operation, invisible, readOnly, ...props } = parseProps(this.props, this.props.operation);
         if (invisible) {
             return null;
+        }
+        if (readOnly) {
+            return <span>{operation.choice}</span>;
         }
         return (
             <Radio.Group onChange={e => operation.setValue(e.target.value)} {...props} value={operation.value}>
@@ -81,9 +84,12 @@ export class OneOfButtonFormAnt extends React.Component<
 @observer
 export class OneOfSelectAnt extends React.Component<BindAntProps<OneOf> & SelectProps> {
     render() {
-        const { operation, invisible, mode, ...props } = parseProps(this.props, this.props.operation);
+        const { operation, invisible, readOnly, mode, ...props } = parseProps(this.props, this.props.operation);
         if (invisible) {
             return null;
+        }
+        if (readOnly) {
+            return <span>{operation.choice}</span>;
         }
         return (
             <Select

--- a/packages/antd/src/__tests__/__snapshots__/OneOfAnt.test.tsx.snap
+++ b/packages/antd/src/__tests__/__snapshots__/OneOfAnt.test.tsx.snap
@@ -68,7 +68,6 @@ exports[`OneOfSelectAnt should render a select control by default 1`] = `
   mode="default"
   onChange={[Function]}
   placeholder="..."
-  readOnly={false}
   showSearch={false}
   transitionName="slide-up"
 >

--- a/packages/moxb/src/one-of/OneOf.ts
+++ b/packages/moxb/src/one-of/OneOf.ts
@@ -16,4 +16,5 @@ export interface BindOneOfChoice<T = string> {
 
 export interface OneOf<T = string> extends Value<T> {
     readonly choices: BindOneOfChoice<T>[];
+    readonly choice: string | undefined;
 }

--- a/packages/moxb/src/one-of/OneOfImpl.ts
+++ b/packages/moxb/src/one-of/OneOfImpl.ts
@@ -20,4 +20,10 @@ export class OneOfImpl<T = string> extends ValueImpl<OneOfImpl, T, OneOfOptions<
             return this.impl.choices || [];
         }
     }
+
+    @computed
+    get choice(): string | undefined {
+        const choice = this.choices.find(c => c.value === this.value);
+        return choice ? choice.label : undefined;
+    }
 }


### PR DESCRIPTION
 - Add a new field to the `OneOf` interface, for getting the current choice's title (if any)
 - Add `readOnly` support to `OneOfButtonAnt` and `OneOfSelectAnt`.
   (The prop was already there, just didn't do anything.)