### PR TITLE
Add PollingUpdaterAnt for displaying periodically updated content

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,7 @@ Follow the principles in [keepachangelog.com](https://keepachangelog.com)!
 ### Added
  * Declare that the `renderUIFragment()` function accepts undefined input, too
  * Added `NavRadioButtonBarAnt` component, which is just like the `NavMenuBarAnt`, but with radio buttons 
+ * Adding `PollingUpdaterAnt` component, for displaying some content that is periodically updated
 
 ### Fixed
  * Fixed a TS warning around btoa-lite

--- a/examples/src/app/ApplicationAnt.tsx
+++ b/examples/src/app/ApplicationAnt.tsx
@@ -21,6 +21,7 @@ import {
     TimePickerAnt,
     ActionToggleButtonAnt,
     ToolTipButton,
+    PollingUpdaterAnt,
 } from '@moxb/antd';
 import { toJSON } from '@moxb/moxb';
 import { Col, Dropdown, Form, Icon, Menu, Row } from 'antd';
@@ -168,6 +169,19 @@ export class ApplicationAnt extends React.Component<{ app?: Application }> {
                             <hr />
                             <h3>Table Component</h3>
                             <TableAnt table={application.testTable} />
+                            <br />
+                            <br />
+                            <PollingUpdaterAnt
+                                operation={{
+                                    updateFrequency: 5,
+                                    title: 'Time watcher',
+                                    update: callback => {
+                                        // A fake/demo update function, which checks the time
+                                        callback(undefined, `Latest time is: ${new Date().toString()}`);
+                                    },
+                                }}
+                            />
+                            <br />
                             <br />
                             <div id="spacer" style={{ paddingBottom: '100px' }} />
                         </Form>

--- a/packages/antd/src/PollingUpdaterAnt.tsx
+++ b/packages/antd/src/PollingUpdaterAnt.tsx
@@ -17,14 +17,14 @@ interface PollingUpdaterImpl {
     readonly updateFrequency: number;
 
     /**
-     * Should we show a pop-up window, with information about update times? (Default: true)
+     * Don't show the pop-up window, with information about update times. (Default: false - show the popup)
      */
-    showPopup?: boolean;
+    noPopup?: boolean;
 
     /**
-     * Should it be possible to trigger an update by clicking?
+     * Disable for mechanism for for triggering an update by clicking. (Default: false - updates are enabled)
      */
-    canClick?: boolean;
+    noUpdateOnClick?: boolean;
 
     /**
      * What should be in the title, when the popup is shown?
@@ -116,22 +116,23 @@ export class PollingUpdaterAnt extends React.Component<PollingUpdaterProps> {
 
     render() {
         const { operation } = this.props;
-        const { title, showPopup, canClick } = operation;
+        const { title, noPopup, noUpdateOnClick } = operation;
 
         const coreContent = this._failed ? (
             <Alert message={this._errorMessage} type={'warning'} />
         ) : (
-            <span onClick={canClick !== false ? this._update : undefined}>
+            <span onClick={noUpdateOnClick ? undefined : this._update}>
                 {renderUIFragment(this._content)} {this._pending && <Spin />}
             </span>
         );
-        const clickText =
-            canClick === false
-                ? undefined
-                : this._lastUpdate
-                ? t('pollingUpdater.clickToUpdate', 'Click to update now.')
-                : t('pollingUpdater.clickToLoad', 'Click to load.');
-        return showPopup !== false ? (
+        const clickText = noUpdateOnClick
+            ? undefined
+            : this._lastUpdate
+            ? t('pollingUpdater.clickToUpdate', 'Click to update now.')
+            : t('pollingUpdater.clickToLoad', 'Click to load.');
+        return noPopup ? (
+            coreContent
+        ) : (
             <Popover
                 content={
                     <span>
@@ -143,8 +144,6 @@ export class PollingUpdaterAnt extends React.Component<PollingUpdaterProps> {
             >
                 {coreContent}
             </Popover>
-        ) : (
-            coreContent
         );
     }
 

--- a/packages/antd/src/PollingUpdaterAnt.tsx
+++ b/packages/antd/src/PollingUpdaterAnt.tsx
@@ -1,0 +1,126 @@
+import * as React from 'react';
+import { Popover, Spin, Alert } from 'antd';
+import { observable } from 'mobx';
+import { observer } from 'mobx-react';
+import { t } from '@moxb/moxb';
+import { renderUIFragment, UIFragment } from './not-antd';
+
+/**
+ * A callback type that will be passed to the update function
+ */
+export type PollingUpdaterCallback = (errorMessage: string | undefined, content: UIFragment | undefined) => void;
+
+interface PollingUpdaterImpl {
+    /**
+     * How many seconds between the updates?
+     */
+    readonly updateFrequency: number;
+
+    /**
+     * What should be in the title, when the popup is shown?
+     */
+    title: string;
+
+    /**
+     * This will be called to trigger an update
+     */
+    update(callback: PollingUpdaterCallback): void;
+}
+
+interface PollingUpdaterProps {
+    operation: PollingUpdaterImpl;
+}
+
+/**
+ * The PollingUpdaterAnt component displays some content that is periodically updated.
+ *
+ * The rate of updates (polling frequency) is configurable.
+ * There is a pop-up, which explains how much time is left till the next update.
+ * Immediate update is also possible, when clicking on the content.
+ */
+@observer
+export class PollingUpdaterAnt extends React.Component<PollingUpdaterProps> {
+    @observable protected _pending = false;
+    @observable protected _content: UIFragment | undefined;
+    @observable protected _failed = false;
+    @observable protected _errorMessage: string | undefined;
+    @observable protected _lastUpdate: number | undefined;
+    @observable protected _updateText: string | undefined;
+
+    protected _alive = false;
+    protected _polling: any;
+    protected _counter: any;
+
+    protected _update() {
+        this._pending = true;
+        this._lastUpdate = Date.now();
+        this.props.operation.update((errorMessage, content) => {
+            this._pending = false;
+            this._errorMessage = errorMessage;
+            this._failed = !!errorMessage;
+            this._content = content;
+        });
+    }
+
+    /**
+     * Start the polling and time counter
+     */
+    protected _awaken() {
+        if (this._alive) {
+            return;
+        }
+        this._alive = true;
+        this._update();
+        this._polling = setInterval(() => this._update(), this.props.operation.updateFrequency * 1000);
+        this._counter = setInterval(() => {
+            const age = this._lastUpdate ? Math.round((Date.now() - this._lastUpdate) / 1000) : undefined;
+            this._updateText =
+                age !== undefined
+                    ? t(
+                          'pollingUpdater.updateAge.text',
+                          'Updated {{age}} seconds ago. Next update in {{left}} seconds. Click to update now.',
+                          { age, left: this.props.operation.updateFrequency - age }
+                      )
+                    : 'Click to load';
+        }, 1000);
+    }
+
+    /**
+     * Stop the polling and time counter
+     * @private
+     */
+    protected _ignore() {
+        if (!this._alive) {
+            return false;
+        }
+        this._alive = false;
+        clearInterval(this._polling);
+        clearInterval(this._counter);
+    }
+
+    constructor(props: PollingUpdaterProps) {
+        super(props);
+        this._update = this._update.bind(this);
+    }
+
+    render() {
+        const { operation } = this.props;
+        return this._failed ? (
+            <Alert message={this._errorMessage} type={'warning'} />
+        ) : (
+            <Popover content={<span>{this._updateText}</span>} title={operation.title} trigger="hover">
+                <span onClick={this._update}>
+                    {renderUIFragment(this._content)} {this._pending && <Spin />}
+                </span>
+            </Popover>
+        );
+    }
+
+    componentDidMount() {
+        this._awaken();
+    }
+
+    componentWillUnmount() {
+        this._ignore();
+    }
+}

--- a/packages/antd/src/index.ts
+++ b/packages/antd/src/index.ts
@@ -17,3 +17,4 @@ export * from './TagAnt';
 export * from './ToolTipAnt';
 export * from './not-antd';
 export * from './routing';
+export * from './PollingUpdaterAnt';


### PR DESCRIPTION
The `PollingUpdaterAnt` is a widget for displaying some data that is periodically updated.

The update function must be supplied by the application.
The polling will be managed by this widget.
The polling frequency can be configured.
When hovering the pointer above the content, we will see some information about when the data was updated last. Immediate clicking is available by clicking.
