### PR TITLE
Add onOpen handle to ModalOptions

### DIFF
--- a/packages/moxb/src/modal/ModalImpl.ts
+++ b/packages/moxb/src/modal/ModalImpl.ts
@@ -4,6 +4,7 @@ import { Modal, ModalActions } from './Modal';
 export interface ModalOptions<T, A> {
     header?(data: T): string;
     actions(data: T): A;
+    onOpen?(): void;
     onClose?(): void;
     size?: 'mini' | 'tiny' | 'small' | 'large' | 'fullscreen';
 }
@@ -22,6 +23,11 @@ export class ModalImpl<T, A extends ModalActions = ModalActions> implements Moda
     @action.bound
     show(data: T) {
         this.data = data;
+
+        if (this.impl.onOpen) {
+            this.impl.onOpen();
+        }
+
         this.open = true;
     }
     close() {


### PR DESCRIPTION
On the `Modal` interface there is an `onOpen` function, however we didn't support it because `antd` doesn't support it.

This PR adds a simple way to simulate this `onOpen` functionality. This is prerequisite for job-multi-creation