### PR TITLE
NavRadioButtonsBarAnt: accept only one extra widget

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,10 @@ Follow the principles in [keepachangelog.com](https://keepachangelog.com)!
 ### Breaking Changes
  * `Modal` now takes an interface with actions (instead of an array). However, the array still works but
     will be removed soon.
+ * `NavRadioButtonBarAnt` used to take and `extras` prop (for a list of extra components to display),
+    but this caused some problems, because React doesn't like rendering components from a list
+    without unique keys. (And since the components can come from different sources, there is no way
+    to reliably assign keys.) Reducing it to accepting a single component.
  
 ### Added
  * Declare that the `renderUIFragment()` function accepts undefined input, too

--- a/packages/antd/src/routing/NavRadioButtonsBarAnt.tsx
+++ b/packages/antd/src/routing/NavRadioButtonsBarAnt.tsx
@@ -14,7 +14,7 @@ export interface NavRadioButtonBarProps<DataType>
     /**
      * Any extra menu items to add
      */
-    extras?: JSX.Element[];
+    extra?: JSX.Element;
 
     /**
      * Any direct styles to apply
@@ -29,7 +29,7 @@ export interface NavRadioButtonBarProps<DataType>
  */
 export class NavRadioButtonBarAnt<DataType> extends React.Component<NavRadioButtonBarProps<DataType>> {
     protected getLocationDependantStateSpaceHandler() {
-        const { id, children: _children, extras, style, ...stateProps } = this.props;
+        const { id, children: _children, extra, style, ...stateProps } = this.props;
 
         return new LocationDependentStateSpaceHandlerImpl({
             ...stateProps,
@@ -44,7 +44,7 @@ export class NavRadioButtonBarAnt<DataType> extends React.Component<NavRadioButt
             UIFragmentSpec,
             DataType
         > = this.getLocationDependantStateSpaceHandler();
-        const { extras, style } = this.props;
+        const { extra, style } = this.props;
         const operation = new OneOfImpl({
             id: 'oneOf.' + this.props.id,
             getValue: () => states.getActiveSubStateMenuKeys(true)[0],
@@ -62,7 +62,7 @@ export class NavRadioButtonBarAnt<DataType> extends React.Component<NavRadioButt
         return (
             <div id={'radioButtonMenu.' + this.props.id} style={style}>
                 <OneOfButtonAnt operation={operation} />
-                {...extras || []}
+                {extra}
             </div>
         );
     }


### PR DESCRIPTION

`NavRadioButtonBarAnt` used to take and `extras` prop (for a list of extra components to display),
    but this caused some problems, because React doesn't like rendering components from a list
    without unique keys. (And since the components can come from different sources, there is no way
    to reliably assign keys.) Reducing it to accepting a single component.

This causes a breaking API change (for those apps that use `NavRadioButtonsBarAnt` with extra widgets).
I will create a matching PR for `ves`.