### PR TITLE
Fix `mountAll` option

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -19,6 +19,10 @@ Follow the principles in [keepachangelog.com](https://keepachangelog.com)!
 
 ### Fixed
  * Fixed a TS warning around btoa-lite
+ * When using the `mountAll` option with a menu, rendering of "fallback"
+   content was broken. (Ie. when a non-existent item is requested from the menu.)
+   Also, we were rendering _all_ the sub-states, not only those that were currently
+   available, considering the conditions. These problems have been fixed.  
 
 
 # [v0.2.0-beta.23](https://github.com/moxb/moxb/releases/tag/v0.2.0-beta.23) (2019-05-29)

--- a/packages/antd/src/not-antd/LocationDependentArea.tsx
+++ b/packages/antd/src/not-antd/LocationDependentArea.tsx
@@ -107,13 +107,20 @@ export class LocationDependentArea<DataType> extends React.Component<LocationDep
         const { mountAll } = this.props;
         const wantedChild = this._states.getActiveSubState();
         this.debugLog('wantedChild is', wantedChild);
-        if (mountAll) {
+        if (mountAll && wantedChild) {
             this.debugLog('Rendering all children at once');
-            return this._states._subStatesInContext.map((s, i) => (
-                <div key={`${i}`} style={{ display: s !== wantedChild ? 'none' : undefined }}>
-                    {this.renderSubState(s, s !== wantedChild)}
-                </div>
-            ));
+            return this._states
+                .getFilteredSubStates({
+                    onlyVisible: false,
+                    onlyLeaves: true,
+                    onlySatisfying: true,
+                    noDisplayOnly: true,
+                })
+                .map((s, i) => (
+                    <div key={`${i}`} style={{ display: s !== wantedChild ? 'none' : undefined }}>
+                        {this.renderSubState(s, s !== wantedChild)}
+                    </div>
+                ));
         } else {
             return this.renderSubState(wantedChild);
         }


### PR DESCRIPTION
When using the `mountAll` option with a menu, rendering of "fallback"
content was broken. (Ie. the thing that is shown when a non-existent
item is requested from the menu.)

Also, we were rendering _all_ the sub-states, not only those that were
currently available, considering the conditions.

These problems have been fixed.