### PR TITLE
[VS-139] Extends the NavControl interface

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,9 @@ Follow the principles in [keepachangelog.com](https://keepachangelog.com)!
 
 # v.Next (Current)
 
+### Added
+- [VS-139](https://goessntl.atlassian.net/browse/VS-139) Extend the NavControl interface with new APIs
+  (preparation for page enter and leave hooks)
 
 # [v0.2.0-beta.25](https://github.com/moxb/moxb/releases/tag/v0.2.0-beta.25) (2019-06-27)
 

--- a/examples/src/menus/MoreMenusAnt.tsx
+++ b/examples/src/menus/MoreMenusAnt.tsx
@@ -1,5 +1,5 @@
 import { LinkAnt, MenuAndContentAnt, TextFormAnt, UIFragmentSpec, NavTabBarAnt } from '@moxb/antd';
-import { Navigable } from '@moxb/moxb';
+import { NavigableContent } from '@moxb/moxb';
 
 import { Col, Row } from 'antd';
 import { inject } from 'mobx-react';
@@ -8,9 +8,9 @@ import { UrlStore } from '../store/UrlStore';
 import { subMenu1, subMenu2 } from './SubMenu';
 
 @inject('url')
-export class MoreMenusAnt extends React.Component<{ url?: UrlStore } & Navigable<any, UIFragmentSpec>> {
+export class MoreMenusAnt extends React.Component<{ url?: UrlStore } & NavigableContent<any, UIFragmentSpec>> {
     render() {
-        const { url } = this.props;
+        const { url, navControl } = this.props;
         return (
             <div>
                 <span>Here come some more menus.</span>
@@ -22,6 +22,7 @@ export class MoreMenusAnt extends React.Component<{ url?: UrlStore } & Navigable
                             parsedTokens={this.props.parsedTokens}
                             // arg={url!.number}
                             subStates={subMenu1}
+                            navControl={navControl}
                             mode="horizontal"
                             useTokenMappings={true}
                             fallback="Unknown number"
@@ -64,6 +65,7 @@ export class MoreMenusAnt extends React.Component<{ url?: UrlStore } & Navigable
                             arg={url!.color}
                             mode="left"
                             subStates={subMenu2}
+                            navControl={navControl}
                             fallback="Unknown color"
                             debug={false}
                         />

--- a/examples/src/menus/SubMenu.tsx
+++ b/examples/src/menus/SubMenu.tsx
@@ -103,6 +103,7 @@ class GreenBlocks extends React.Component<NavigableContent<string, UIFragmentSpe
         navControl.registerStateHooks({
             getLeaveQuestion: () => 'Do you really want to leave these nice green blocks?',
         });
+        (global as any).greenControl = navControl;
     }
 
     render() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1988,6 +1988,19 @@
       "resolved": "https://registry.npmjs.org/@types/jest-diff/-/jest-diff-20.0.1.tgz",
       "integrity": "sha512-yALhelO3i0hqZwhjtcr6dYyaLoCHbAMshwtj6cGxTvHZAKXHsYGdff6E8EPw3xLKY0ELUTQ69Q1rQiJENnccMA=="
     },
+    "@types/lodash": {
+      "version": "4.14.136",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.136.tgz",
+      "integrity": "sha512-0GJhzBdvsW2RUccNHOBkabI8HZVdOXmXbXhuKlDEd5Vv12P7oAVGfomGp3Ne21o5D/qu1WmthlNKFaoZJJeErA=="
+    },
+    "@types/lodash.flatten": {
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/@types/lodash.flatten/-/lodash.flatten-4.4.6.tgz",
+      "integrity": "sha512-omCBl4M8EJSmf2DZqh4/zwjgXQpzC7YO/PXTcG8rI9r7xun8CohrHeNx8HZRkqWc61uJfIaZop9MwJEXPVssHw==",
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
     "@types/marked": {
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/@types/marked/-/marked-0.6.5.tgz",
@@ -7797,6 +7810,11 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
       "integrity": "sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg="
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
     },
     "lodash.flattendeep": {
       "version": "4.4.0",

--- a/packages/antd/src/not-antd/LocationDependentArea.tsx
+++ b/packages/antd/src/not-antd/LocationDependentArea.tsx
@@ -85,12 +85,14 @@ export class LocationDependentArea<DataType> extends React.Component<LocationDep
         subState: SubStateInContext<UIFragment, UIFragmentSpec, DataType> | null,
         invisible?: boolean
     ) {
+        const { navControl, id } = this.props;
         const extraProps: any = {
             key: subState ? subState.key : 'missing',
         };
         if (invisible) {
             extraProps.invisible = true;
         }
+        const parentName = 'LocationDependentArea:' + id + ':' + (subState ? subState.menuKey : 'null');
         return renderSubStateCore({
             state: subState,
             navigationContext: this.props,
@@ -98,7 +100,16 @@ export class LocationDependentArea<DataType> extends React.Component<LocationDep
             checkCondition: false, // We don't ever get to select this sub-state if the condition fails
             extraProps,
             navControl: {
-                registerStateHooks: hooks => this._states.registerNavStateHooksForSubState(subState, hooks),
+                getParentName: () => parentName,
+                getAncestorNames: () => [...(navControl ? navControl.getAncestorNames() : []), parentName],
+                isActive: () =>
+                    (!navControl || navControl.isActive()) && // Is the whole area active?
+                    !!subState && // The fallback is never really considered to be active
+                    this._states.isSubStateActive(subState), // Is the current sub-state active?
+                registerStateHooks: (hooks, componentId?) =>
+                    this._states.registerNavStateHooksForSubState(subState!, hooks, componentId),
+                unregisterStateHooks: (componentId?) =>
+                    this._states.unregisterNavStateHooksForSubState(subState!, componentId),
             },
         });
     }

--- a/packages/antd/src/routing/NavTabBarAnt.tsx
+++ b/packages/antd/src/routing/NavTabBarAnt.tsx
@@ -54,6 +54,7 @@ export class NavTabBarAnt<DataType> extends React.Component<NavTabProps<DataType
         states: LocationDependentStateSpaceHandler<UIFragment, UIFragmentSpec, DataType>,
         state: SubStateInContext<UIFragment, UIFragmentSpec, DataType>
     ) {
+        const { navControl } = this.props;
         const { label, key, menuKey, itemClassName, newWindow, linkStyle, linkClassName, title } = state;
 
         const url = states.getUrlForSubState(state);
@@ -74,6 +75,7 @@ export class NavTabBarAnt<DataType> extends React.Component<NavTabProps<DataType
         }
         const tabLabel = <Anchor.Anchor {...anchorProps} />;
         const id = idToDomId(`${parentId}.${menuKey}`);
+        const parentName = 'NavTabBarAnt:' + this.props.id + ':' + menuKey;
         return (
             <TabPane data-testid={id} key={menuKey} tab={tabLabel} {...itemProps}>
                 {states.isSubStateActive(state) &&
@@ -83,7 +85,13 @@ export class NavTabBarAnt<DataType> extends React.Component<NavTabProps<DataType
                         tokenIncrease: state ? state.totalPathTokens.length : 1,
                         checkCondition: false,
                         navControl: {
-                            registerStateHooks: hooks => states.registerNavStateHooksForSubState(state, hooks),
+                            getParentName: () => parentName,
+                            getAncestorNames: () => [...(navControl ? navControl.getAncestorNames() : []), parentName],
+                            registerStateHooks: (hooks, componentId?) =>
+                                states.registerNavStateHooksForSubState(state, hooks, componentId),
+                            unregisterStateHooks: (componentId?) =>
+                                states.unregisterNavStateHooksForSubState(state, componentId),
+                            isActive: () => (!navControl || navControl.isActive()) && states.isSubStateActive(state),
                         },
                     })}
             </TabPane>

--- a/packages/moxb/package-lock.json
+++ b/packages/moxb/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@moxb/moxb",
-  "version": "0.2.0-beta.24",
+  "version": "0.2.0-beta.27",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -39,6 +39,21 @@
       "integrity": "sha512-yALhelO3i0hqZwhjtcr6dYyaLoCHbAMshwtj6cGxTvHZAKXHsYGdff6E8EPw3xLKY0ELUTQ69Q1rQiJENnccMA==",
       "dev": true
     },
+    "@types/lodash": {
+      "version": "4.14.136",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.136.tgz",
+      "integrity": "sha512-0GJhzBdvsW2RUccNHOBkabI8HZVdOXmXbXhuKlDEd5Vv12P7oAVGfomGp3Ne21o5D/qu1WmthlNKFaoZJJeErA==",
+      "dev": true
+    },
+    "@types/lodash.flatten": {
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/@types/lodash.flatten/-/lodash.flatten-4.4.6.tgz",
+      "integrity": "sha512-omCBl4M8EJSmf2DZqh4/zwjgXQpzC7YO/PXTcG8rI9r7xun8CohrHeNx8HZRkqWc61uJfIaZop9MwJEXPVssHw==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
     "@types/urijs": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.1.tgz",
@@ -67,6 +82,11 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
     },
     "loose-envify": {
       "version": "1.4.0",

--- a/packages/moxb/package.json
+++ b/packages/moxb/package.json
@@ -52,6 +52,7 @@
     "@types/atob": "2.1.2",
     "@types/history": "4.7.2",
     "@types/jest": "24.0.13",
+    "@types/lodash.flatten": "^4.4.6",
     "@types/urijs": "1.19.1",
     "mobx": "5.10.0",
     "tslib": "1.9.3"
@@ -59,6 +60,7 @@
   "dependencies": {
     "btoa-lite": "1.0.0",
     "history": "4.9.0",
+    "lodash.flatten": "^4.4.0",
     "urijs": "1.19.1"
   }
 }

--- a/packages/moxb/src/routing/index.ts
+++ b/packages/moxb/src/routing/index.ts
@@ -52,6 +52,7 @@ export {
     LocationDependentStateSpaceHandler,
     LocationDependentStateSpaceHandlerProps,
     LocationDependentStateSpaceHandlerImpl,
+    HookMap,
 } from './location-state-space';
 
 export {

--- a/packages/moxb/src/routing/location-state-space/LocationDependentStateSpaceHandler.ts
+++ b/packages/moxb/src/routing/location-state-space/LocationDependentStateSpaceHandler.ts
@@ -1,5 +1,5 @@
 import { SuccessCallback, UpdateMethod, UsesLocation } from '../location-manager';
-import { Navigable } from '../navigable';
+import { NavControl, Navigable } from '../navigable';
 import { UsesTokenManager } from '../TokenManager';
 import { UrlArg } from '../url-arg';
 import { SubStateInContext } from './state-space/StateSpace';
@@ -21,6 +21,11 @@ export interface LocationDependentStateSpaceHandlerProps<LabelType, WidgetType, 
      * (Required for registering on-leave handlers and such)
      */
     intercept?: boolean;
+
+    /**
+     * If this component is embedded in a larger navigation space, we can pass in some controls
+     */
+    navControl?: NavControl;
 }
 
 /**

--- a/packages/moxb/src/routing/location-state-space/index.ts
+++ b/packages/moxb/src/routing/location-state-space/index.ts
@@ -3,3 +3,4 @@ export {
     LocationDependentStateSpaceHandlerProps,
 } from './LocationDependentStateSpaceHandler';
 export { LocationDependentStateSpaceHandlerImpl } from './LocationDependentStateSpaceHandlerImpl';
+export { HookMap } from './state-space/StateSpaceHandlerImpl';

--- a/packages/moxb/src/routing/location-state-space/state-space/StateSpaceHandler.ts
+++ b/packages/moxb/src/routing/location-state-space/state-space/StateSpaceHandler.ts
@@ -89,12 +89,25 @@ export interface StateSpaceHandler<LabelType, WidgetType, DataType> {
     /**
      * Register navigation state change hooks for a given sub-state
      *
-     * @param subState
-     * @param hooks
+     * @param subState The sub-state to which the hooks belong to
+     * @param hooks The hooks to register
+     * @param componentId An ID for the component (in case there are more than one set of hooks) (Optional)
      */
     registerNavStateHooksForSubState(
-        subState: SubStateInContext<LabelType, WidgetType, DataType> | null,
-        hooks: NavStateHooks
+        subState: SubStateInContext<LabelType, WidgetType, DataType>,
+        hooks: NavStateHooks,
+        componentId?: string
+    ): void;
+
+    /**
+     * Unregister navigation state change hooks for a given sub-state
+     *
+     * @param subState The sub-state to which the hooks belong to
+     * @param componentId An ID for the component (in case there are more than one set of hooks) (Optional)
+     */
+    unregisterNavStateHooksForSubState(
+        subState: SubStateInContext<LabelType, WidgetType, DataType>,
+        componentId?: string
     ): void;
 }
 

--- a/packages/moxb/src/routing/navigable.ts
+++ b/packages/moxb/src/routing/navigable.ts
@@ -28,7 +28,30 @@ export interface NavStateHooks {
  * Nav control interface, to control various aspects of the navigation
  */
 export interface NavControl {
-    registerStateHooks: (hooks: NavStateHooks) => void;
+    /**
+     * Returns the name of the controller component. (For debug.)
+     */
+    getParentName: () => string;
+
+    /**
+     * Returns the names of all parent controller components. (For debug.)
+     */
+    getAncestorNames: () => string[];
+
+    /**
+     * Am I currently active?
+     */
+    isActive: () => boolean;
+
+    /**
+     * Register some hooks to be called on navigation events
+     */
+    registerStateHooks: (hooks: NavStateHooks, componentId?: string) => void;
+
+    /**
+     * Unregister navigation event hooks
+     */
+    unregisterStateHooks: (componentId?: string) => void;
 }
 
 /**


### PR DESCRIPTION
... with two features:

 - Earlier, we could only have one hook for a give sub-state.
   However, it's possible that a page has multiple components
   for the same sub-state, and more than one of those can
   require navigation hooks. So we introduced an optional
   component name that can be passed in when registering hooks.
   This makes it possible to handle hooks for different components
   independently.
 - Also support unregistering hooks.
 - Add support for testing active active status of the current sub-state
 - Add support for describing navigation tree path recursively (for debugging)


This change is fully backward compatible, since the newly introduced parameter is optional.
(So existing application code works without any modification.)

Closes [VS-139].