### PR TITLE
Added a small utility for creating conditional (debug) loggers

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,7 @@ Follow the principles in [keepachangelog.com](https://keepachangelog.com)!
 ### Added
 - [VS-139](https://goessntl.atlassian.net/browse/VS-139) Extend the NavControl interface with new APIs
   (preparation for page enter and leave hooks)
+- Added a small, conditional debug log utility
 
 # [v0.2.0-beta.25](https://github.com/moxb/moxb/releases/tag/v0.2.0-beta.25) (2019-06-27)
 

--- a/packages/meteor/src/MeteorMethod.ts
+++ b/packages/meteor/src/MeteorMethod.ts
@@ -1,5 +1,6 @@
 import { observable } from 'mobx';
 import { meteorCall, MeteorCallback } from './MeteorCall';
+import { getDebugLogger } from '@moxb/moxb';
 
 /**
  * Here, we provide a type-safe way to define and call a Meteor method.
@@ -111,21 +112,20 @@ export function registerMeteorMethod<Input, Output>(
     method: MeteorMethodDefinition<Input, Output>
 ): MeteorMethodControl<Input, Output> {
     const { name, debug, execute, serverOnly } = method;
+    const logger = getDebugLogger('Method ' + name, debug);
     if (Meteor.isServer || !serverOnly) {
-        // console.log('Publishing Meteor method', name);
+        logger.log('Publishing Meteor method', name);
         Meteor.methods({
             [name]: (input: Input) => {
                 // console.log('***Gonna check out if', name, 'is running in a simulation', this);
                 // if (!this || this.isSimulation) {
                 //     return;
                 // }
-                if (debug) {
-                    console.log('Method', name, 'with data', input);
-                }
+                logger.log('with data', input);
+
                 const result = wrapException(execute)(input);
-                if (debug) {
-                    console.log('Method', name, 'returns', result);
-                }
+                logger.log('returns', result);
+
                 return result;
             },
         });

--- a/packages/moxb/src/index.ts
+++ b/packages/moxb/src/index.ts
@@ -2,3 +2,4 @@ export * from './impl';
 export * from './types';
 export * from './routing';
 export * from './decision';
+export * from './util/debugLog';

--- a/packages/moxb/src/routing/tokens.ts
+++ b/packages/moxb/src/routing/tokens.ts
@@ -1,6 +1,8 @@
 /**
  * Decide whether a given token is considered to be empty.
  */
+import { getDebugLogger } from '../util/debugLog';
+
 export function isTokenEmpty(token: string | null | undefined): boolean {
     return token === '' || token === null || token === undefined;
 }
@@ -30,6 +32,7 @@ export function doTokenStringsMatch(
     exactOnly: boolean,
     debugMode?: boolean
 ) {
+    const logger = getDebugLogger('TokenStringMatcher', debugMode);
     let result = true;
     wantedTokens.forEach((token, index) => {
         if (!result) {
@@ -48,23 +51,19 @@ export function doTokenStringsMatch(
         const nextLevel = parsedTokens + wantedTokens.length;
         const nextToken = currentTokens[nextLevel];
         const empty = isTokenEmpty(nextToken);
-        if (debugMode) {
-            console.log(
-                'Testing if this is an exact match.',
-                'nextLevel is',
-                nextLevel,
-                'nextToken is',
-                nextToken,
-                typeof nextToken,
-                'empty?',
-                empty
-            );
-        }
+        logger.log(
+            'Testing if this is an exact match.',
+            'nextLevel is',
+            nextLevel,
+            'nextToken is',
+            nextToken,
+            typeof nextToken,
+            'empty?',
+            empty
+        );
         return empty;
     } else {
-        if (debugMode) {
-            console.log('Not exact match required, returning true');
-        }
+        logger.log('Not exact match required, returning true');
         return true;
     }
 }

--- a/packages/moxb/src/util/debugLog.ts
+++ b/packages/moxb/src/util/debugLog.ts
@@ -1,0 +1,40 @@
+interface Logger {
+    log(...stuff: any[]): void;
+    debug(...stuff: any[]): void;
+    info(...stuff: any[]): void;
+    warn(...stuff: any[]): void;
+    error(...stuff: any[]): void;
+}
+
+const getRealLogger = (prefix: string): Logger => ({
+    log(...stuff) {
+        console.log(prefix, ':', ...stuff);
+    },
+
+    debug(...stuff) {
+        console.debug(prefix, ':', ...stuff);
+    },
+
+    info(...stuff) {
+        console.info(prefix, ':', ...stuff);
+    },
+
+    warn(...stuff) {
+        console.warn(prefix, ':', ...stuff);
+    },
+
+    error(...stuff) {
+        console.error(prefix, ':', ...stuff);
+    },
+});
+
+const fakeLogger: Logger = {
+    log() {},
+    debug() {},
+    info() {},
+    warn() {},
+    error() {},
+};
+
+export const getDebugLogger = (prefix: string, debugMode?: boolean): Logger =>
+    !!debugMode ? getRealLogger(prefix) : fakeLogger;


### PR DESCRIPTION
The idea is the following:
 - You can use `getDebugLogger(prefix, debug)`  to get a logger object (typically at the beginning of a function)
 - When calling this function, we specify whether we are in debug mode, and also an (optional) prefix to use for logging
- Afterwards, you can use `logger.log()` as a drop-in replacement for `console.log()` (It also has `debug()`, `info()`, `warn()` and `error()`, just like console.)
- When debug mode is off, there is no output; when debug mode is on, we dump everything to the console.
