### PR TITLE
Add cached value utility

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,9 @@ Follow the principles in [keepachangelog.com](https://keepachangelog.com)!
   (preparation for page enter and leave hooks)
 - Added a small, conditional debug log utility
 - Added support for hiding ToolTipButtonAnt, via the operator's invisible flag. (Just like normal buttons.)
+- Added a [cached value utility](packages/moxb/src/cached-evaluator/readme.md) to cache values that are expensive
+  to retrieve. The cached value can have an expiration time.
+
 
 # [v0.2.0-beta.25](https://github.com/moxb/moxb/releases/tag/v0.2.0-beta.25) (2019-06-27)
 

--- a/packages/moxb/src/cached-evaluator/CachedEvaluator.ts
+++ b/packages/moxb/src/cached-evaluator/CachedEvaluator.ts
@@ -1,0 +1,48 @@
+/**
+ * Props for configuring an evaluator
+ */
+export interface CachedEvaluatorProps<Input, Output> {
+    /**
+     * The name of this evaluator, for debugging
+     */
+    readonly name?: string;
+
+    /**
+     * How do we yield a key from the input data?
+     */
+    readonly getKey: (input: Input) => string;
+
+    /**
+     * The actual function to run
+     */
+    readonly getValue: (input: Input) => Output;
+
+    /**
+     * How long should we cache results?
+     *
+     * The default value is 300s - 5 min
+     */
+    readonly normalCacheSeconds?: number;
+
+    /**
+     * How long should we cache the error, if there was an exception?
+     *
+     * The default value is 60s - 1 min
+     */
+    readonly errorCacheSeconds?: number;
+
+    /**
+     * Should this run in debug mode?
+     */
+    debugMode?: boolean;
+
+    // TODO: Add a parameter to configure cache pruning behavior
+    // (when getting a value, we might want to look for other, obsolete value, and expunge them from the cache.)
+}
+
+/**
+ * A cached evaluator evaluates a function calls, and caches the result for some time
+ */
+export interface CachedEvaluator<Input, Output> {
+    get(input: Input, forceRefresh?: boolean): Output;
+}

--- a/packages/moxb/src/cached-evaluator/CachedEvaluatorImpl.ts
+++ b/packages/moxb/src/cached-evaluator/CachedEvaluatorImpl.ts
@@ -1,0 +1,44 @@
+import { CachedEvaluator, CachedEvaluatorProps } from './CachedEvaluator';
+import { getDebugLogger } from '../util/debugLog';
+
+interface ObjectMap<T> {
+    [index: string]: T;
+}
+
+const getTime = (): number => new Date().getTime() / 1000;
+
+export class CachedEvaluatorImpl<Input, Output> implements CachedEvaluator<Input, Output> {
+    private readonly _failed: ObjectMap<any> = {};
+    private readonly _value: ObjectMap<Output> = {};
+    private readonly _lastTested: ObjectMap<number> = {};
+
+    constructor(private readonly props: CachedEvaluatorProps<Input, Output>) {}
+
+    get(input: Input, forceRefresh = false) {
+        const { name, debugMode, getKey, errorCacheSeconds = 60, normalCacheSeconds = 300, getValue } = this.props;
+        const logger = getDebugLogger('CachedEvaluator-' + name, debugMode);
+        const key = getKey(input);
+        const error = this._failed[key];
+        if (!forceRefresh && !!error && getTime() - this._lastTested[key] < errorCacheSeconds) {
+            // Last time this was run, there was an error, and it's not yet time to try again
+            logger.log('Running for', key, 'has failed not too long ago; not retrying...');
+            throw error;
+        }
+        if (!forceRefresh && !error && getTime() - this._lastTested[key] < normalCacheSeconds) {
+            // Last time this was run, there was no error, and it's not yet time to try again
+            logger.log('We have a value for', key, 'from not too long ago; not retrying.');
+            return this._value[key];
+        }
+        // It's time to try this again
+        logger.log('Executing for', input);
+        this._lastTested[key] = getTime();
+        try {
+            this._value[key] = getValue(input);
+            delete this._failed[key];
+            return this._value[key];
+        } catch (newError) {
+            this._failed[key] = newError;
+            throw newError;
+        }
+    }
+}

--- a/packages/moxb/src/cached-evaluator/CachedOptionalValue.ts
+++ b/packages/moxb/src/cached-evaluator/CachedOptionalValue.ts
@@ -1,0 +1,56 @@
+/**
+ * Props for configuring a cached value
+ */
+export interface CachedOptionalValueProps<Output> {
+    /**
+     * The name of this value.
+     *
+     * Used for debugging.
+     */
+    readonly name?: string;
+
+    /**
+     * The actual function to run
+     *
+     * This function is executed when we need a fresh value.
+     * In case of a failure, it is supposed to return undefined.
+     * (Which will also be cached.)
+     */
+    readonly getValue: () => Output | undefined;
+
+    /**
+     * How long should we cache results?
+     *
+     * The default value is 300s - 5 min
+     */
+    readonly normalCacheSeconds?: number;
+
+    /**
+     * How long should we cache the undefined result?
+     *
+     * When we are holding the undefined result, it will be returned again and again,
+     * every time get() is called, until the next refresh.
+     *
+     * The default value is 60s - 1 min
+     */
+    readonly errorCacheSeconds?: number;
+
+    /**
+     * Should this run in debug mode?
+     */
+    debugMode?: boolean;
+}
+
+/**
+ * A CachedOptionalValue instance holds a cached value, which is optional. (Ie it can also be undefined.)
+ *
+ * You can call `get()` to get the value, or `get(true)` to force a refresh.
+ * When refreshing, the value is calculated by the user-supplied getter function.
+ * Even if you don't force a refresh, the value will be refreshed from time to time,
+ * depending on the parameters used when initializing the CachedValue store.
+ * If the getter function fails (and returns undefined), then this behavior is cached
+ * and repeated by subsequent get() calls, until it's time to refresh again.
+ */
+export interface CachedOptionalValue<Output> {
+    get(forceRefresh?: boolean): Output | undefined;
+}

--- a/packages/moxb/src/cached-evaluator/CachedOptionalValueImpl.ts
+++ b/packages/moxb/src/cached-evaluator/CachedOptionalValueImpl.ts
@@ -1,0 +1,32 @@
+import { getDebugLogger } from '../util/debugLog';
+import { CachedOptionalValue, CachedOptionalValueProps } from './CachedOptionalValue';
+
+const getTime = (): number => new Date().getTime() / 1000;
+
+export class CachedOptionalValueImpl<Output> implements CachedOptionalValue<Output> {
+    private _value?: Output;
+    private _lastTested?: number;
+
+    constructor(private readonly props: CachedOptionalValueProps<Output>) {}
+
+    // tslint:disable-next-line:cyclomatic-complexity
+    get(forceRefresh = false): Output | undefined {
+        const { name, debugMode, errorCacheSeconds = 60, normalCacheSeconds = 300, getValue } = this.props;
+        const logger = getDebugLogger('CacheOptionalValue-' + name, debugMode);
+        const failed = this._value === undefined;
+        if (!forceRefresh && !!this._lastTested && failed && getTime() - this._lastTested < errorCacheSeconds) {
+            // Last time this was run, there was an error, and it's not
+            logger.log('Running has failed not too long ago; not retrying...');
+            return undefined;
+        }
+        if (!forceRefresh && !!this._lastTested && !failed && getTime() - this._lastTested < normalCacheSeconds) {
+            // Last time this was run, there was no error, and it's not yet time to try again
+            logger.log('We have a value from not too long ago; not retrying.');
+            return this._value;
+        }
+        // It's time to try this again
+        logger.log('Executing');
+        this._lastTested = getTime();
+        return (this._value = getValue());
+    }
+}

--- a/packages/moxb/src/cached-evaluator/CachedValue.ts
+++ b/packages/moxb/src/cached-evaluator/CachedValue.ts
@@ -1,0 +1,55 @@
+/**
+ * Props for configuring a cached value
+ */
+export interface CachedValueProps<Output> {
+    /**
+     * The name of this value.
+     *
+     * Used for debugging.
+     */
+    readonly name?: string;
+
+    /**
+     * The actual function to run
+     *
+     * This function is executed when we need a fresh value.
+     * It is allowed to throw an exception. (Which will also be cached.)
+     */
+    readonly getValue: () => Output;
+
+    /**
+     * How long should we cache results?
+     *
+     * Default value is 300 secs - 5 minutes
+     */
+    readonly normalCacheSeconds?: number;
+
+    /**
+     * How long should we cache the error, if there was an exception?
+     *
+     * When we are holding the cached exception, it will be thrown again and again,
+     * every time get() is called, until the next refresh.
+     *
+     * Default value is 60 secs - 1 minute
+     */
+    readonly errorCacheSeconds?: number;
+
+    /**
+     * Should this run in debug mode?
+     */
+    debugMode?: boolean;
+}
+
+/**
+ * A CachedValue instance holds a cached value.
+ *
+ * You can call `get()` to get the value, or `get(true)` to force a refresh.
+ * When refreshing, the value is calculated by the user-supplied getter function.
+ * Even if you don't force a refresh, the value will be refreshed from time to time,
+ * depending on the parameters used when initializing the CachedValue store.
+ * If the getter function fails (and throws an exception), then this behavior is cached
+ * and repeated by subsequent get() calls, until it's time to refresh again.
+ */
+export interface CachedValue<Output> {
+    get(forceRefresh?: boolean): Output;
+}

--- a/packages/moxb/src/cached-evaluator/CachedValueImpl.ts
+++ b/packages/moxb/src/cached-evaluator/CachedValueImpl.ts
@@ -1,0 +1,46 @@
+import { getDebugLogger } from '../util/debugLog';
+import { CachedValue, CachedValueProps } from './CachedValue';
+
+const getTime = (): number => new Date().getTime() / 1000;
+
+export class CachedValueImpl<Output> implements CachedValue<Output> {
+    private _failed: any;
+    private _value?: Output;
+    private _lastTested?: number;
+
+    constructor(private readonly props: CachedValueProps<Output>) {}
+
+    // tslint:disable-next-line:cyclomatic-complexity
+    get(forceRefresh = false): Output {
+        const { name, debugMode, errorCacheSeconds = 60, normalCacheSeconds = 300, getValue } = this.props;
+        const logger = getDebugLogger('CachedValue-' + name, debugMode);
+        const error = this._failed;
+        if (!forceRefresh && !!this._lastTested && !!error && getTime() - this._lastTested < errorCacheSeconds) {
+            // Last time this was run, there was an error, and it's not yet time to try again
+            logger.log('Running has failed not too long ago; not retrying...');
+            throw error;
+        }
+        if (
+            !forceRefresh &&
+            !!this._lastTested &&
+            !error &&
+            !!this._value &&
+            getTime() - this._lastTested < normalCacheSeconds
+        ) {
+            // Last time this was run, there was no error, and it's not yet time to try again
+            logger.log('We have a value from not too long ago; not retrying.');
+            return this._value;
+        }
+        // It's time to try this again
+        logger.log('Executing');
+        this._lastTested = getTime();
+        try {
+            this._value = getValue();
+            delete this._failed;
+            return this._value;
+        } catch (newError) {
+            this._failed = newError;
+            throw newError;
+        }
+    }
+}

--- a/packages/moxb/src/cached-evaluator/index.ts
+++ b/packages/moxb/src/cached-evaluator/index.ts
@@ -1,0 +1,21 @@
+import { CachedValueImpl } from './CachedValueImpl';
+import { CachedValue, CachedValueProps } from './CachedValue';
+
+import { CachedEvaluatorImpl } from './CachedEvaluatorImpl';
+import { CachedEvaluator, CachedEvaluatorProps } from './CachedEvaluator';
+import { CachedOptionalValue, CachedOptionalValueProps } from './CachedOptionalValue';
+import { CachedOptionalValueImpl } from './CachedOptionalValueImpl';
+
+export function getCachedValue<Output>(props: CachedValueProps<Output>): CachedValue<Output> {
+    return new CachedValueImpl<Output>(props);
+}
+
+export function getCachedOptionalValue<Output>(props: CachedOptionalValueProps<Output>): CachedOptionalValue<Output> {
+    return new CachedOptionalValueImpl<Output>(props);
+}
+
+export function getCachedEvaluator<Input, Output>(
+    props: CachedEvaluatorProps<Input, Output>
+): CachedEvaluator<Input, Output> {
+    return new CachedEvaluatorImpl<Input, Output>(props);
+}

--- a/packages/moxb/src/cached-evaluator/readme.md
+++ b/packages/moxb/src/cached-evaluator/readme.md
@@ -1,0 +1,65 @@
+# Intro
+
+The purpose of these utilities is to provide a utility to cache a value
+(or more values) that come from an outside source, and we want to periodically
+update, but also cache for a while, because of the cost of updating.
+
+The idea is that we don't want to check the value more than, say, once in
+every five minutes. We have a function for actually getting the value,
+and we wrap this caching object around that function.
+
+The users of the value will call `get()` on this caching object, which will
+either call the _real_ function to get the data (if it's time), or just
+get the value from the cache.
+
+
+# Selecting the right version
+
+There are three slighly different implementations, based on the semantics
+of the getter function.
+
+## Single value, exception
+
+Let's assume that we want to cache a single value, which is returned by
+a function, which sometimes throws an exception. In this case, we want
+to recognize the situation that the execution of the function has failed,
+and also cache this information, so that subsequent get() calls will also
+get the same exception (stored in the cache), and also we might want to
+retry this sooner than the normal cache expiration period would allow.
+
+In this case you need a `CachedValue`, which can be created using the 
+`getCachedValue()` function.
+
+The behavior can be configured by the passed configuration object.
+
+## Single value, undefined
+
+Let's assume that we want to cache a single value, which is returned by
+a function, which doesn't throw an exception, but sometimes it returns an
+undefined value. In this case, we want to recognize the situation that
+the execution of the function has failed, and also cache this information,
+so that subsequent get() calls will also get the same undefined value,
+and also we might want to retry this sooner than the normal cache expiration
+period would allow.
+
+In this case you need a `CachedOptionalValue`, which can be created using the 
+`getCachedOptionalValue()` function. 
+
+The behavior can be configured by the passed configuration object.
+
+## Multiple values, exception
+
+Let's assume that the getter function has an input parameter, so it can query
+multiple values. We want to cache all these values separately. The function
+can also throw an exception. In this case, we want to recognize the situation
+that the execution of the function has failed, and also cache this information,
+so that subsequent get() calls with the same input parameter will also get the
+same exception (stored in the cache), and also we might want to retry this
+sooner than the normal cache expiration period would allow.
+
+In this case you need a `CachedEvaluator`, which can be created using the 
+`getCachedEvaluator()` function.
+
+The behavior can be configured by the passed configuration object.
+
+

--- a/packages/moxb/src/index.ts
+++ b/packages/moxb/src/index.ts
@@ -3,3 +3,4 @@ export * from './types';
 export * from './routing';
 export * from './decision';
 export * from './util/debugLog';
+export * from './cached-evaluator';


### PR DESCRIPTION
The purpose of these utilities is to provide a utility to cache a value
(or more values) that come from an outside source, and we want to periodically
update, but also cache for a while, because of the cost of updating.

The idea is that we don't want to check the value more than, say, once in
every five minutes. We have a function for actually getting the value,
and we wrap this caching object around that function.

The users of the value will call `get()` on this caching object, which will
either call the _real_ function to get the data (if it's time), or just
get the value from the cache.
