### PR TITLE
Make it possible to override the help on form items

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,9 @@ Follow the principles in [keepachangelog.com](https://keepachangelog.com)!
 
 # v.Next (Current)
 
+### Added
+ - The ability to override the `help` field on form items
+
 # [v0.2.0-beta.53](https://github.com/moxb/moxb/releases/tag/v0.2.0-beta.53) (2020-11-05)
 
 ### Added

--- a/packages/antd/src/BindAnt.tsx
+++ b/packages/antd/src/BindAnt.tsx
@@ -16,9 +16,10 @@ export interface BindAntProps<T extends Bind> {
  * The direct props override properties of the operation!
  */
 export function parseProps<T, O>(bindProps: T, _op: O): T & O {
-    let { id, operation, invisible, label, disabled, reason, readOnly, children, ...props } = bindProps as any;
+    let { id, operation, invisible, label, help, disabled, reason, readOnly, children, ...props } = bindProps as any;
     id = typeof id !== 'undefined' ? id : operation.domId;
     label = typeof label !== 'undefined' ? label : operation.label;
+    help = typeof help !== 'undefined' ? help : operation.help;
     disabled = typeof disabled !== 'undefined' ? disabled : operation.disabled;
     reason = typeof reason !== 'undefined' ? reason : operation.reason;
     readOnly = typeof readOnly !== 'undefined' ? readOnly : operation.readOnly;
@@ -27,6 +28,7 @@ export function parseProps<T, O>(bindProps: T, _op: O): T & O {
         id,
         operation,
         label,
+        help,
         disabled,
         reason,
         readOnly,

--- a/packages/antd/src/FormItemAnt.tsx
+++ b/packages/antd/src/FormItemAnt.tsx
@@ -27,6 +27,7 @@ export class FormItemAnt extends React.Component<BindFormItemAntProps> {
             id,
             children,
             label,
+            help,
             formStyle,
             labelCol,
             wrapperCol,
@@ -43,7 +44,7 @@ export class FormItemAnt extends React.Component<BindFormItemAntProps> {
             <Form.Item
                 htmlFor={fullId}
                 data-testid={fullId}
-                label={labelWithHelp(label, operation.help, fullId)}
+                label={labelWithHelp(label, help, fullId)}
                 style={formStyle || undefined}
                 extra={extraLabel}
                 labelCol={labelCol}


### PR DESCRIPTION
When we have a BoolAnt, and we put it into a form via BoolFormAnt,
then the label is displayed twice: before and after the checkbox.

Since we usually don't want that, we have already set up FormItemAnt
so that the "label" prop can be overridden, so that we are not forced
to display the label coming directly for the operation.

The current change extends this support to the "help" field of the operation.
The help is displayed in a popup when the user hovers above the small (?) besides
the label; basically it's an extension of the label. With this change, it can be
overridden the same way as it works with the label.