### PR TITLE
Fix a mobx reactivity issue with menus

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,10 @@ Follow the principles in [keepachangelog.com](https://keepachangelog.com)!
 # v.Next (Current)
 
  - Fixed a missing dependency and a few invalid imports in the example app
+ - Fixed a mobx reactivity issues when we were passing in functions / methods instead
+   of classes. In this case, the @observer wrapping the object might not suffice,
+   since we are calling individial functions of the objects directly.
+   Wrapping `observer()` around the components inside the menu does the trick.
 
 # [v0.2.0-beta.54](https://github.com/moxb/moxb/releases/tag/v0.2.0-beta.54) (2021-01-13)
 

--- a/packages/html/src/UIFragment.ts
+++ b/packages/html/src/UIFragment.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { isForwardRef } from './isForwardRef';
+import { observer } from 'mobx-react';
 
 type Component<T> = (props: T) => JSX.Element | null;
 
@@ -28,8 +29,8 @@ export const renderUIFragment = (fragment: UIFragment | undefined, props: Object
             typeof (fragment as any).type === 'function' &&
             (fragment as any).$$typeof !== Symbol.for('react.element'))
     ) {
-        // console.log('using createElement');
-        return React.createElement(fragment as any, props);
+        // console.log('using createElement with observer');
+        return React.createElement(observer(fragment as any), props);
     } else {
         // console.log('Rendering this directly');
         return fragment as JSX.Element;


### PR DESCRIPTION
When we were passing in functions / methods (instead of classes) to some of the navigational components,
the existing `@observer` wrapping the object might not suffice, since we are calling individual functions of the objects directly.

Wrapping `observer()` around the components inside the menu system does the trick.