### PR TITLE
Small fix for SliderAnt spacing

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,9 @@ Follow the principles in [keepachangelog.com](https://keepachangelog.com)!
 
 # v.Next (Current)
 
+### Fixed
+ - Small fix for slider spacing
+
 # [v0.2.0-beta.56](https://github.com/moxb/moxb/releases/tag/v0.2.0-beta.56) (2021-01-22)
 
 ### Added

--- a/packages/antd/src/SliderAnt.tsx
+++ b/packages/antd/src/SliderAnt.tsx
@@ -39,10 +39,10 @@ export class SliderAnt extends React.Component<SliderAntProps> {
         const formatter = (value?: number | string) => (operation.unit ? `${value}${operation.unit}` : `${value}`);
         return showNumber ? (
             <Row>
-                <Col span={1}>
+                <Col span={2}>
                     <span style={{ marginRight: '1em' }}>{formatter(operation.value)}</span>
                 </Col>
-                <Col span={15}>{this.renderSlider()}</Col>
+                <Col span={22}>{this.renderSlider()}</Col>
             </Row>
         ) : (
             this.renderSlider()


### PR DESCRIPTION
Antd divides the grid into 24 pieces instead of 16 pieces (which is the bootstrap standard)