### PR TITLE
NativeUrlSchema: support being embedded within some path

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,9 @@ Follow the principles in [keepachangelog.com](https://keepachangelog.com)!
 
 # v.Next (Current)
 
+- Extended NativeUrlSchema so that it's also usable when the app doesn't live
+  at the root of the website
+
 # [v0.2.0-beta.58](https://github.com/moxb/moxb/releases/tag/v0.2.0-beta.58) (2021-01-28)
 
 ### Added

--- a/packages/moxb/src/routing/navigation-references/NavRefImpl.ts
+++ b/packages/moxb/src/routing/navigation-references/NavRefImpl.ts
@@ -7,9 +7,7 @@ import { SuccessCallback, UpdateMethod } from '../location-manager';
 /**
  * Internal: a type to store nav references
  */
-interface NavRefMap {
-    [key: string]: NavRef<any>;
-}
+type NavRefMap = Record<string, NavRef<any>>;
 
 /**
  * Internal: a map to store nav references

--- a/packages/moxb/src/routing/url-schema/NativeUrlSchema.ts
+++ b/packages/moxb/src/routing/url-schema/NativeUrlSchema.ts
@@ -3,26 +3,65 @@ import { Path as MyLocation } from 'history';
 import { Query, UrlSchema } from './UrlSchema';
 
 /**
+ * Config options for the Native URL Shema
+ */
+export interface NativeUrlSchemaConfig {
+    /**
+     * How many path tokens are there in the path leading to our app?
+     *
+     * Ie. if our app lives at the root of the website, then this is 0, which is the default.
+     * If our app lives at /app, then this is one.
+     */
+    level?: number;
+}
+
+/**
  * This is simple URL schema that uses the native path and search feature.
  *
  * This looks nice in the URL, but is only applicable if server-side routing is set up
  * in such a way that will return the app consistently, even if the path is different.
  */
 export class NativeUrlSchema implements UrlSchema {
-    public getPathTokens(location: MyLocation): string[] {
+    constructor(private readonly _config: NativeUrlSchemaConfig = {}) {}
+
+    /**
+     * Fetch the raw path tokens, without considering the path of the app
+     */
+    private _getRawPathTokens(location: MyLocation): string[] {
         const pathname = location.pathname;
         const raw = pathname[0] === '/' ? pathname.substr(1) : pathname;
         return raw.split('/').filter((token) => token.length);
+    }
+
+    /**
+     * Get the current path tokens inside the app
+     *
+     * To get this, we need to remove the path tokens that lead _to_ the app.
+     */
+    public getPathTokens(location: MyLocation): string[] {
+        const { level = 0 } = this._config;
+        return this._getRawPathTokens(location).slice(level);
     }
 
     public getQuery(location: MyLocation): Query {
         return new MyURI().search(location.search).search(true);
     }
 
+    /**
+     * Calculate a new location inside the app
+     */
     public getLocation(location: MyLocation, pathTokens: string[], query: Query): MyLocation {
+        // First we need to find out the path tokens leading _to_ the app
+        const oldPathTokens = this._getRawPathTokens(location);
+        const { level = 0 } = this._config;
+        const keptTokens = oldPathTokens.slice(0, level);
+
+        // Concatenate the tokens leading to the app, and the new path inside the app
+        const newPathTokens = [...keptTokens, ...pathTokens];
+
         return {
             ...location,
-            pathname: '/' + pathTokens.join('/'),
+            pathname: '/' + newPathTokens.join('/'),
             search: new MyURI().search(query).search(),
         };
     }

--- a/packages/moxb/src/routing/url-schema/UrlSchema.ts
+++ b/packages/moxb/src/routing/url-schema/UrlSchema.ts
@@ -3,9 +3,7 @@ import { Path as MyLocation, To as LocationDescriptorObject } from 'history';
 /**
  * A simple Map/Dict type used to represent the URL arguments.
  */
-export interface Query {
-    [key: string]: string;
-}
+export type Query = Record<string, string>;
 
 /***
  * A method for storing path tokens and URL arguments in the URL.


### PR DESCRIPTION
Up to now, the `NativeUrlSchema` only worked if our app lives at the root of the website.

This change enables it to be used in other situations, when our app is embedded under some path. (Ie. /app )