### PR TITLE
Fix support for the target HTML arg on NavLink and friends

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,7 +4,12 @@ Follow the principles in [keepachangelog.com](https://keepachangelog.com)!
 
 # v.Next (Current)
 
+### Fixed
+ - Fixed support for the `target` HTML arg on `NavLink` and it's derivatives.
+
 # [v0.2.0-beta.65](https://github.com/moxb/moxb/releases/tag/v0.2.0-beta.65) (2021-02-10)
+
+### Added
 - OneOfFormAnt: add support for vertical layout of choices (like OneOfAnt)
 
 # [v0.2.0-beta.64](https://github.com/moxb/moxb/releases/tag/v0.2.0-beta.64) (2021-02-05)

--- a/packages/html/src/NavLink.tsx
+++ b/packages/html/src/NavLink.tsx
@@ -46,8 +46,13 @@ export class NavLink extends React.Component<NavLinkProps & UsesLocation> {
 
     public render() {
         const { children, ...remnants } = this.props;
+        const { target } = this.props;
         return (
-            <Anchor.Anchor href={locationToUrl(this.getWantedLocation())} onClick={this.handleClick} {...remnants}>
+            <Anchor.Anchor
+                href={locationToUrl(this.getWantedLocation())}
+                onClick={target ? undefined : this.handleClick}
+                {...remnants}
+            >
                 {children}
             </Anchor.Anchor>
         );


### PR DESCRIPTION
The trick here is that if the `target` argument is specified on the link, we shouldn't install a click handler: just let the browser do what it would normally do.