### PR TITLE
Fix the handling of the target attribute on NavLinkButtonAnt

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,7 @@ Follow the principles in [keepachangelog.com](https://keepachangelog.com)!
 ### Fixed
  - Fixed support for the `target` HTML arg on `NavLink` and it's derivatives.
  - Fixed handling of requests for non-existent tabs on NavTabBarAnt.
+ - Fixed support for the `target` HTML arg on `NavLinkButtonAnt` and it's derivatives.
 
 # [v0.2.0-beta.65](https://github.com/moxb/moxb/releases/tag/v0.2.0-beta.65) (2021-02-10)
 

--- a/packages/antd/src/routing/NavLinkButtonAnt.tsx
+++ b/packages/antd/src/routing/NavLinkButtonAnt.tsx
@@ -5,6 +5,7 @@ import { Path as MyLocation } from 'history';
 import { inject, observer } from 'mobx-react';
 import * as React from 'react';
 import { AnchorParams } from '@moxb/html/dist/Anchor';
+import { NavLink } from '@moxb/html';
 
 /**
  * Everything except the actual target specification
@@ -55,14 +56,39 @@ export class NavLinkButtonAnt extends React.Component<NavLinkButtonAntProps & Us
         const { buttonProps: extraButtonProps = {}, children, ...remnants } = this.props;
         const url = locationToUrl(this.getWantedLocation());
 
+        const { target } = this.props;
+
         const { label, className, disabled, style, title } = remnants;
         const buttonProps: ButtonProps = {
-            onClick: this.handleClick,
+            onClick: target ? undefined : this.handleClick,
             className,
             disabled,
             title,
             style,
         };
+        if (target) {
+            // When the link target is set, we don't want to use a button for the navigation.
+            // Instead, we will use a real HTML link on the button, and let the browser
+            // handle the actual navigation step. (Which will open a new tab anyway.)
+            const { to, position, appendTokens, removeTokenCount, argChanges, toRef, disabled } = this.props;
+            return (
+                <Button data-testid={url} {...(extraButtonProps as any)} {...buttonProps}>
+                    <NavLink
+                        target={target}
+                        label={label}
+                        to={to}
+                        position={position}
+                        appendTokens={appendTokens}
+                        removeTokenCount={removeTokenCount}
+                        argChanges={argChanges}
+                        toRef={toRef}
+                        disabled={disabled}
+                    >
+                        {children}
+                    </NavLink>
+                </Button>
+            );
+        }
         return (
             <Button data-testid={url} {...(extraButtonProps as any)} {...buttonProps}>
                 {label}


### PR DESCRIPTION
When the target HTML attribute is set, we shouldn't use a button and a click handler
for navigation, but we should use NavLink to render an actual HTML link instead,
and let the browser handle the navigation.