### PR TITLE
Enhance BoundLink with help, enabled, disabled 

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,9 @@ Follow the principles in [keepachangelog.com](https://keepachangelog.com)!
 
 # v.Next (Current)
 
+### Added
+ - BoundLink: added help, enabled and disabled options.
+
 ### Fixed
  - Fixed support for the `target` HTML arg on `NavLink` and it's derivatives.
  - Fixed handling of requests for non-existent tabs on NavTabBarAnt.

--- a/packages/antd/src/routing/BoundNavLinkButtonAnt.tsx
+++ b/packages/antd/src/routing/BoundNavLinkButtonAnt.tsx
@@ -1,4 +1,4 @@
-import { BoundLink } from '@moxb/moxb';
+import { BoundLink, readDecision } from '@moxb/moxb';
 import { observer } from 'mobx-react';
 import * as React from 'react';
 import { NavLinkButtonAnt, NavLinkButtonAntParams, NavLinkButtonAntProps } from './NavLinkButtonAnt';
@@ -24,6 +24,8 @@ export class BoundNavLinkButtonAnt extends React.Component<BoundNavLinkButtonAnt
             removeTokenCount: operation.removeTokenCount,
             toRef: operation.toRef,
             label: operation.label,
+            title: operation.help,
+            disabled: readDecision(operation.disabled),
             ...rest,
         };
 

--- a/packages/html/src/BoundNavLink.tsx
+++ b/packages/html/src/BoundNavLink.tsx
@@ -1,4 +1,4 @@
-import { BoundLink } from '@moxb/moxb';
+import { BoundLink, readDecision } from '@moxb/moxb';
 import { observer } from 'mobx-react';
 import * as React from 'react';
 import { NavLink, NavLinkParams, NavLinkProps } from './NavLink';
@@ -27,6 +27,8 @@ export class BoundNavLink extends React.Component<BoundNavLinkProps> {
             removeTokenCount: operation.removeTokenCount,
             label: operation.label,
             toRef: operation.toRef,
+            title: operation.help,
+            disabled: readDecision(operation.disabled),
             ...rest,
         };
 

--- a/packages/moxb/src/routing/linking/BoundLink.ts
+++ b/packages/moxb/src/routing/linking/BoundLink.ts
@@ -2,6 +2,7 @@
  * This interface describes all the data that is needed to display a navigation link
  */
 import { CoreLinkProps } from './CoreLinkProps';
+import { AnyDecision } from '../../decision';
 
 export interface BoundLink extends CoreLinkProps {
     // The actual target of the link is described in CoreLinkProps
@@ -17,7 +18,17 @@ export interface BoundLink extends CoreLinkProps {
     readonly label: string;
 
     /**
+     * Help to be displayed (in a popup), if any
+     */
+    readonly help: string | undefined;
+
+    /**
      * Should this be hidden?
      */
     readonly invisible: boolean;
+
+    /**
+     * Should this be disabled?
+     */
+    readonly disabled: AnyDecision;
 }


### PR DESCRIPTION
This adds the help, enabled and disabled options to the configuration of BoundLink.
It all works exactly the same is it works for Action.

   * * *

The depends on https://github.com/moxb/moxb/pull/209; please merge that first, then rebase this one.
(Dropping the first commit automatically.)