### PR TITLE
Input widget improvements

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,9 @@ Follow the principles in [keepachangelog.com](https://keepachangelog.com)!
 
 # v.Next (Current)
 
+### Changed
+- Input widget improvements
+
 # [v0.2.0-beta.67](https://github.com/moxb/moxb/releases/tag/v0.2.0-beta.67) (2021-02-17)
 
 ### Added

--- a/examples/src/app/ApplicationAnt.tsx
+++ b/examples/src/app/ApplicationAnt.tsx
@@ -10,6 +10,7 @@ import {
     LabelMarkdownAnt,
     ManyOfAnt,
     ManyOfCheckboxAnt,
+    ManyOfSwitchAnt,
     ModalAnt,
     NumericFormAnt,
     OneOfAnt,
@@ -157,12 +158,20 @@ export class ApplicationAnt extends React.Component<{ app?: Application }> {
                             <ManyOfAnt style={{ width: '200px' }} operation={application.testManyOf} />
                             <br />
                             <br />
-                            <h3>ManyOfAnt Component - multiple selection</h3>
+                            <h3>ManyOfAnt Component - chose from available</h3>
                             <ManyOfAnt style={{ width: '200px' }} mode="multiple" operation={application.testManyOf} />
                             <br />
                             <br />
                             <h3>ManyOfCheckboxAnt Component - multiple selection with checkboxes</h3>
                             <ManyOfCheckboxAnt style={{ width: '200px' }} operation={application.testManyOf} />
+                            <br />
+                            <br />
+                            <h3>ManyOfSwitchboxAnt Component - multiple selection with switches</h3>
+                            <ManyOfSwitchAnt operation={application.testManyOf} />
+                            <br />
+                            <br />
+                            <h3>ManyOfSwitchboxAnt Component - multiple selection with switches - vertical</h3>
+                            <ManyOfSwitchAnt operation={application.testManyOf} verticalDisplay={true} />
                             <br />
                             <br />
                             <h3>OneOf - RadioButton Component</h3>

--- a/examples/src/app/ApplicationAnt.tsx
+++ b/examples/src/app/ApplicationAnt.tsx
@@ -171,7 +171,7 @@ export class ApplicationAnt extends React.Component<{ app?: Application }> {
                             <br />
                             <br />
                             <h3>ManyOfSwitchboxAnt Component - multiple selection with switches - vertical</h3>
-                            <ManyOfSwitchAnt operation={application.testManyOf} verticalDisplay={true} />
+                            <ManyOfSwitchAnt operation={application.testManyOf} vertical={true} />
                             <br />
                             <br />
                             <h3>OneOf - RadioButton Component</h3>

--- a/packages/antd/src/BoolAnt.tsx
+++ b/packages/antd/src/BoolAnt.tsx
@@ -1,7 +1,7 @@
 import { Bool } from '@moxb/moxb';
 import { Checkbox, Switch } from 'antd';
 import { CheckboxProps } from 'antd/lib/checkbox';
-import { SwitchProps } from 'antd/lib/switch';
+import { SwitchSize } from 'antd/lib/switch';
 import { FormItemProps } from 'antd/lib/form/FormItem';
 import { observer } from 'mobx-react';
 import * as React from 'react';
@@ -32,29 +32,41 @@ export class BoolAnt extends React.Component<BindAntProps<Bool> & CheckboxProps>
     }
 }
 
+export interface AllowedSwitchProps {
+    prefixCls?: string;
+    size?: SwitchSize;
+    className?: string;
+    checkedChildren?: React.ReactNode;
+    unCheckedChildren?: React.ReactNode;
+    autoFocus?: boolean;
+    style?: React.CSSProperties;
+}
+
 @observer
-export class BoolSwitchAnt extends React.Component<BindAntProps<Bool> & SwitchProps> {
+export class BoolSwitchAnt extends React.Component<BindAntProps<Bool> & AllowedSwitchProps> {
     render() {
-        const { operation, invisible, children, label, checkedChildren, unCheckedChildren, ...props } = parseProps(
+        const { operation, invisible, children, label, reason, disabled, ...props } = parseProps(
             this.props,
             this.props.operation
         );
         if (invisible) {
             return null;
         }
-
+        const switchClassName = disabled ? 'ant-checkbox-disabled' : '';
+        const labelClassName = disabled ? '' : 'ant-checkbox-wrapper';
         return (
-            <span>
-                <Switch
-                    data-testid={operation.id}
-                    checked={operation.value}
-                    onChange={() => operation.toggle()}
-                    checkedChildren={checkedChildren}
-                    unCheckedChildren={unCheckedChildren}
-                    {...props}
-                />
-                &nbsp;
-                <span onClick={() => operation.toggle()} style={{ cursor: 'pointer' }}>
+            <span title={reason}>
+                <span className={switchClassName}>
+                    <Switch
+                        disabled={disabled}
+                        data-testid={operation.id}
+                        checked={operation.value}
+                        onChange={() => operation.toggle()}
+                        {...props}
+                    />
+                </span>
+                &nbsp; &nbsp;
+                <span onClick={() => operation.toggle()} className={labelClassName}>
                     {labelWithHelp(label, operation.help, operation.id)}
                 </span>
             </span>
@@ -78,7 +90,9 @@ export class BoolFormAnt extends React.Component<BindAntProps<Bool> & Partial<Fo
 }
 
 @observer
-export class BoolSwitchFormAnt extends React.Component<BindAntProps<Bool> & Partial<FormItemProps> & SwitchProps> {
+export class BoolSwitchFormAnt extends React.Component<
+    BindAntProps<Bool> & Partial<FormItemProps> & AllowedSwitchProps
+> {
     render() {
         const { operation, invisible, ...props } = parsePropsForChild(this.props, this.props.operation);
         if (invisible) {

--- a/packages/antd/src/BoolAnt.tsx
+++ b/packages/antd/src/BoolAnt.tsx
@@ -11,23 +11,28 @@ import { FormItemAnt, parsePropsForChild } from './FormItemAnt';
 @observer
 export class BoolAnt extends React.Component<BindAntProps<Bool> & CheckboxProps> {
     render() {
-        const { operation, invisible, children, label, ...props } = parseProps(this.props, this.props.operation);
+        const { operation, invisible, children, label, reason, ...props } = parseProps(
+            this.props,
+            this.props.operation
+        );
         if (invisible) {
             return null;
         }
         // a null value renders the checkbox in intermediate state!
         const indeterminate = operation.value == null;
         return (
-            <Checkbox
-                data-testid={operation.id}
-                checked={operation.value}
-                onChange={() => operation.toggle()}
-                indeterminate={indeterminate}
-                {...props}
-            >
-                {children}
-                {labelWithHelp(label, operation.help, operation.id)}
-            </Checkbox>
+            <span title={reason}>
+                <Checkbox
+                    data-testid={operation.id}
+                    checked={operation.value}
+                    onChange={() => operation.toggle()}
+                    indeterminate={indeterminate}
+                    {...props}
+                >
+                    {children}
+                    {labelWithHelp(label, operation.help, operation.id)}
+                </Checkbox>
+            </span>
         );
     }
 }

--- a/packages/antd/src/DatePickerAnt.tsx
+++ b/packages/antd/src/DatePickerAnt.tsx
@@ -19,18 +19,20 @@ export type BindDatePickerAntProps = BindDatePickerAntBasicProps & DatePickerPro
 @observer
 export class DatePickerAnt extends React.Component<BindDatePickerAntProps> {
     render() {
-        const { operation, invisible, ...props } = parseProps(this.props, this.props.operation);
+        const { operation, invisible, reason, ...props } = parseProps(this.props, this.props.operation);
         if (invisible) {
             return null;
         }
         return (
-            <DatePicker
-                data-testid={operation.id}
-                placeholder={operation.placeholder}
-                value={operation.value}
-                onChange={(date: moment.Moment, _dateString: string) => operation.setValue(date)}
-                {...(props as any)}
-            />
+            <span title={reason}>
+                <DatePicker
+                    data-testid={operation.id}
+                    placeholder={operation.placeholder}
+                    value={operation.value}
+                    onChange={(date: moment.Moment, _dateString: string) => operation.setValue(date)}
+                    {...(props as any)}
+                />
+            </span>
         );
     }
 }

--- a/packages/antd/src/ManyOfAnt.tsx
+++ b/packages/antd/src/ManyOfAnt.tsx
@@ -1,12 +1,14 @@
 import { idToDomId, ManyOf } from '@moxb/moxb';
-import { Checkbox, Col, Row, Select } from 'antd';
+import { Checkbox, Col, Row, Select, Switch } from 'antd';
 import { CheckboxGroupProps } from 'antd/lib/checkbox';
+import { SwitchChangeEventHandler } from 'antd/lib/switch';
 import { toJS } from 'mobx';
 import { observer } from 'mobx-react';
 import * as React from 'react';
 import { BindAntProps, labelWithHelp, parseProps } from './BindAnt';
 import { BindFormItemAntProps, FormItemAnt, parsePropsForChild } from './FormItemAnt';
 import { SelectProps } from 'antd/lib/select';
+import { AllowedSwitchProps } from './BoolAnt';
 
 @observer
 export class ManyOfAnt extends React.Component<BindAntProps<ManyOf> & SelectProps<any>> {
@@ -122,6 +124,120 @@ export class ManyOfCheckboxFormAnt extends React.Component<
         return (
             <FormItemAnt operation={operation} {...(this.props as any)}>
                 <ManyOfCheckboxAnt operation={operation} {...props} />
+            </FormItemAnt>
+        );
+    }
+}
+
+@observer
+export class ManyOfSwitchAnt extends React.Component<BindAntProps<ManyOf> & AllowedSwitchProps> {
+    private _toggle(value: string) {
+        const { operation, readOnly, disabled } = parseProps(this.props, this.props.operation);
+        if (readOnly || disabled) {
+        } else {
+            operation.toggle(value);
+        }
+    }
+
+    private readonly _switchHandlerCache: Record<string, SwitchChangeEventHandler> = {};
+
+    private _getSwitchHandler(value: string): SwitchChangeEventHandler {
+        let result = this._switchHandlerCache[value];
+        if (!result) {
+            result = this._switchHandlerCache[value] = () => {
+                this._toggle(value);
+            };
+        }
+        return result;
+    }
+
+    private readonly _clickHandlers: Record<string, React.MouseEventHandler> = {};
+
+    private _getClickHandler(value: string): React.MouseEventHandler {
+        let result = this._clickHandlers[value];
+        if (!result) {
+            result = this._clickHandlers[value] = () => {
+                this._toggle(value);
+            };
+        }
+        return result;
+    }
+
+    render() {
+        const { operation, invisible, disabled, children, verticalDisplay, reason, ...props } = parseProps(
+            this.props,
+            this.props.operation
+        );
+        if (invisible || operation.invisible) {
+            return null;
+        }
+        const switchClassName = disabled ? 'ant-checkbox-disabled' : '';
+        const labelClassName = disabled ? '' : 'ant-checkbox-wrapper';
+
+        const choices = verticalDisplay
+            ? operation.choices.map((opt: any) => (
+                  <Row key={opt.value} style={{ width: '100%' }}>
+                      <Col span={24}>
+                          <span title={reason}>
+                              <span className={switchClassName}>
+                                  <Switch
+                                      data-testid={idToDomId(operation.id + '.' + opt.value)}
+                                      checked={operation.isSelected(opt.value)}
+                                      onChange={this._getSwitchHandler(opt.value)}
+                                      disabled={disabled}
+                                      {...props}
+                                  />
+                              </span>
+                              &nbsp; &nbsp;
+                              <span onClick={this._getClickHandler(opt.value)} className={labelClassName}>
+                                  {labelWithHelp(opt.label, opt.help)}
+                              </span>
+                          </span>
+                      </Col>
+                  </Row>
+              ))
+            : operation.choices.map((opt: any) => (
+                  <Col key={opt.value}>
+                      <span title={reason}>
+                          <span className={switchClassName}>
+                              <Switch
+                                  data-testid={idToDomId(operation.id + '.' + opt.value)}
+                                  checked={operation.isSelected(opt.value)}
+                                  onChange={this._getSwitchHandler(opt.value)}
+                                  disabled={disabled}
+                                  {...props}
+                              />
+                          </span>
+                          &nbsp; &nbsp;
+                          <span onClick={this._getClickHandler(opt.value)} className={labelClassName}>
+                              {labelWithHelp(opt.label, opt.help)}
+                          </span>
+                          &nbsp; &nbsp; &nbsp; &nbsp;
+                      </span>
+                  </Col>
+              ));
+
+        return (
+            <Row>
+                {choices}
+                {children}
+            </Row>
+        );
+    }
+}
+
+@observer
+export class ManyOfSwitchFormAnt extends React.Component<
+    AllowedSwitchProps & BindAntProps<ManyOf> & BindFormItemAntProps
+> {
+    render() {
+        const { operation, invisible, ...props } = parsePropsForChild(this.props, this.props.operation);
+        if (invisible) {
+            return null;
+        }
+        return (
+            <FormItemAnt operation={operation} {...(this.props as any)}>
+                <ManyOfSwitchAnt operation={operation} {...props} />
             </FormItemAnt>
         );
     }

--- a/packages/antd/src/ManyOfAnt.tsx
+++ b/packages/antd/src/ManyOfAnt.tsx
@@ -201,6 +201,7 @@ export class ManyOfSwitchAnt extends React.Component<BindAntProps<ManyOf> & Allo
                                       checked={operation.isSelected(opt.value)}
                                       onChange={this._getSwitchHandler(opt.value)}
                                       disabled={disabled}
+                                      size={'small'}
                                       {...props}
                                   />
                               </span>
@@ -221,6 +222,7 @@ export class ManyOfSwitchAnt extends React.Component<BindAntProps<ManyOf> & Allo
                                   checked={operation.isSelected(opt.value)}
                                   onChange={this._getSwitchHandler(opt.value)}
                                   disabled={disabled}
+                                  size={'small'}
                                   {...props}
                               />
                           </span>

--- a/packages/antd/src/ManyOfAnt.tsx
+++ b/packages/antd/src/ManyOfAnt.tsx
@@ -11,7 +11,7 @@ import { SelectProps } from 'antd/lib/select';
 @observer
 export class ManyOfAnt extends React.Component<BindAntProps<ManyOf> & SelectProps<any>> {
     render() {
-        const { operation, invisible, mode, children, defaultValue, ...props } = parseProps(
+        const { operation, invisible, mode, children, defaultValue, reason, ...props } = parseProps(
             this.props,
             this.props.operation
         );
@@ -21,26 +21,28 @@ export class ManyOfAnt extends React.Component<BindAntProps<ManyOf> & SelectProp
         // make sure the value is not a mobx object...
         const value = toJS(operation.value);
         return (
-            <Select
-                data-testid={operation.id}
-                onChange={(selectionValue: any) => operation.setValue(selectionValue)}
-                value={value || undefined}
-                placeholder={operation.placeholder}
-                defaultValue={defaultValue}
-                mode={mode}
-                {...props}
-            >
-                {operation.choices.map((opt: any) => (
-                    <Select.Option
-                        data-testid={idToDomId(operation.id + '.' + opt.value)}
-                        key={opt.value}
-                        value={opt.value}
-                    >
-                        {opt.label}
-                    </Select.Option>
-                ))}
-                {children}
-            </Select>
+            <span title={reason}>
+                <Select
+                    data-testid={operation.id}
+                    onChange={(selectionValue: any) => operation.setValue(selectionValue)}
+                    value={value || undefined}
+                    placeholder={operation.placeholder}
+                    defaultValue={defaultValue}
+                    mode={mode}
+                    {...props}
+                >
+                    {operation.choices.map((opt: any) => (
+                        <Select.Option
+                            data-testid={idToDomId(operation.id + '.' + opt.value)}
+                            key={opt.value}
+                            value={opt.value}
+                        >
+                            {opt.label}
+                        </Select.Option>
+                    ))}
+                    {children}
+                </Select>
+            </span>
         );
     }
 }
@@ -48,7 +50,10 @@ export class ManyOfAnt extends React.Component<BindAntProps<ManyOf> & SelectProp
 @observer
 export class ManyOfCheckboxAnt extends React.Component<BindAntProps<ManyOf> & CheckboxGroupProps> {
     render() {
-        const { operation, invisible, children, defaultValue, ...props } = parseProps(this.props, this.props.operation);
+        const { operation, invisible, children, defaultValue, reason, ...props } = parseProps(
+            this.props,
+            this.props.operation
+        );
         if (invisible || operation.invisible) {
             return null;
         }
@@ -57,7 +62,7 @@ export class ManyOfCheckboxAnt extends React.Component<BindAntProps<ManyOf> & Ch
 
         const choices = this.props.operation.verticalDisplay
             ? operation.choices.map((opt: any) => (
-                  <Row key={opt.value} style={{ width: '100%' }}>
+                  <Row title={reason} key={opt.value} style={{ width: '100%' }}>
                       <Col span={24}>
                           <Checkbox data-testid={idToDomId(operation.id + '.' + opt.value)} value={opt.value}>
                               {opt.label}
@@ -66,7 +71,7 @@ export class ManyOfCheckboxAnt extends React.Component<BindAntProps<ManyOf> & Ch
                   </Row>
               ))
             : operation.choices.map((opt: any) => (
-                  <Col key={opt.value}>
+                  <Col title={reason} key={opt.value}>
                       <Checkbox data-testid={idToDomId(operation.id + '.' + opt.value)} value={opt.value}>
                           {opt.label}
                       </Checkbox>

--- a/packages/antd/src/ManyOfAnt.tsx
+++ b/packages/antd/src/ManyOfAnt.tsx
@@ -4,7 +4,7 @@ import { CheckboxGroupProps } from 'antd/lib/checkbox';
 import { toJS } from 'mobx';
 import { observer } from 'mobx-react';
 import * as React from 'react';
-import { BindAntProps, parseProps } from './BindAnt';
+import { BindAntProps, labelWithHelp, parseProps } from './BindAnt';
 import { BindFormItemAntProps, FormItemAnt, parsePropsForChild } from './FormItemAnt';
 import { SelectProps } from 'antd/lib/select';
 
@@ -65,7 +65,7 @@ export class ManyOfCheckboxAnt extends React.Component<BindAntProps<ManyOf> & Ch
                   <Row title={reason} key={opt.value} style={{ width: '100%' }}>
                       <Col span={24}>
                           <Checkbox data-testid={idToDomId(operation.id + '.' + opt.value)} value={opt.value}>
-                              {opt.label}
+                              {labelWithHelp(opt.label, opt.help)}
                           </Checkbox>
                       </Col>
                   </Row>
@@ -73,7 +73,7 @@ export class ManyOfCheckboxAnt extends React.Component<BindAntProps<ManyOf> & Ch
             : operation.choices.map((opt: any) => (
                   <Col title={reason} key={opt.value}>
                       <Checkbox data-testid={idToDomId(operation.id + '.' + opt.value)} value={opt.value}>
-                          {opt.label}
+                          {labelWithHelp(opt.label, opt.help)}
                       </Checkbox>
                   </Col>
               ));

--- a/packages/antd/src/ManyOfAnt.tsx
+++ b/packages/antd/src/ManyOfAnt.tsx
@@ -49,10 +49,19 @@ export class ManyOfAnt extends React.Component<BindAntProps<ManyOf> & SelectProp
     }
 }
 
+export interface ManyOfCheckboxAntProps {
+    /**
+     * Should we align the items vertically, instead of horizontally?
+     */
+    vertical?: boolean;
+}
+
 @observer
-export class ManyOfCheckboxAnt extends React.Component<BindAntProps<ManyOf> & CheckboxGroupProps> {
+export class ManyOfCheckboxAnt extends React.Component<
+    BindAntProps<ManyOf> & CheckboxGroupProps & ManyOfCheckboxAntProps
+> {
     render() {
-        const { operation, invisible, children, defaultValue, reason, ...props } = parseProps(
+        const { operation, invisible, children, defaultValue, reason, vertical, ...props } = parseProps(
             this.props,
             this.props.operation
         );
@@ -62,7 +71,7 @@ export class ManyOfCheckboxAnt extends React.Component<BindAntProps<ManyOf> & Ch
         // make sure the value is not a mobx object...
         const value = toJS(operation.value);
 
-        const choices = this.props.operation.verticalDisplay
+        const choices = vertical
             ? operation.choices.map((opt: any) => (
                   <Row title={reason} key={opt.value} style={{ width: '100%' }}>
                       <Col span={24}>
@@ -114,7 +123,7 @@ export class ManyOfFormAnt extends React.Component<SelectProps<ManyOf> & BindAnt
 
 @observer
 export class ManyOfCheckboxFormAnt extends React.Component<
-    CheckboxGroupProps & BindAntProps<ManyOf> & BindFormItemAntProps
+    CheckboxGroupProps & BindAntProps<ManyOf> & BindFormItemAntProps & ManyOfCheckboxAnt
 > {
     render() {
         const { operation, invisible, ...props } = parsePropsForChild(this.props, this.props.operation);
@@ -129,8 +138,15 @@ export class ManyOfCheckboxFormAnt extends React.Component<
     }
 }
 
+export interface ManyOfSwitchAntProps {
+    /**
+     * Should we align the choices vertically, instead of horizontelly?
+     */
+    vertical?: boolean;
+}
+
 @observer
-export class ManyOfSwitchAnt extends React.Component<BindAntProps<ManyOf> & AllowedSwitchProps> {
+export class ManyOfSwitchAnt extends React.Component<BindAntProps<ManyOf> & AllowedSwitchProps & ManyOfSwitchAntProps> {
     private _toggle(value: string) {
         const { operation, readOnly, disabled } = parseProps(this.props, this.props.operation);
         if (readOnly || disabled) {
@@ -164,7 +180,7 @@ export class ManyOfSwitchAnt extends React.Component<BindAntProps<ManyOf> & Allo
     }
 
     render() {
-        const { operation, invisible, disabled, children, verticalDisplay, reason, ...props } = parseProps(
+        const { operation, invisible, disabled, children, vertical, reason, ...props } = parseProps(
             this.props,
             this.props.operation
         );
@@ -174,7 +190,7 @@ export class ManyOfSwitchAnt extends React.Component<BindAntProps<ManyOf> & Allo
         const switchClassName = disabled ? 'ant-checkbox-disabled' : '';
         const labelClassName = disabled ? '' : 'ant-checkbox-wrapper';
 
-        const choices = verticalDisplay
+        const choices = vertical
             ? operation.choices.map((opt: any) => (
                   <Row key={opt.value} style={{ width: '100%' }}>
                       <Col span={24}>
@@ -228,7 +244,7 @@ export class ManyOfSwitchAnt extends React.Component<BindAntProps<ManyOf> & Allo
 
 @observer
 export class ManyOfSwitchFormAnt extends React.Component<
-    AllowedSwitchProps & BindAntProps<ManyOf> & BindFormItemAntProps
+    AllowedSwitchProps & BindAntProps<ManyOf> & BindFormItemAntProps & ManyOfSwitchAntProps
 > {
     render() {
         const { operation, invisible, ...props } = parsePropsForChild(this.props, this.props.operation);

--- a/packages/antd/src/NumericAnt.tsx
+++ b/packages/antd/src/NumericAnt.tsx
@@ -10,7 +10,7 @@ import { FormItemAnt, parsePropsForChild } from './FormItemAnt';
 @observer
 export class NumericAnt extends React.Component<BindAntProps<Numeric> & InputNumberProps> {
     render() {
-        const { operation, id, invisible, size, ...props } = parseProps(this.props, this.props.operation);
+        const { operation, id, invisible, size, reason, ...props } = parseProps(this.props, this.props.operation);
         if (invisible) {
             return null;
         }
@@ -19,6 +19,7 @@ export class NumericAnt extends React.Component<BindAntProps<Numeric> & InputNum
             operation.unit ? parseInt(value!.replace(`${operation.unit}`, '') || '0') : parseInt(value || '0');
         return (
             <InputNumber
+                title={reason}
                 id={id}
                 data-testid={operation.id}
                 step={operation.step}

--- a/packages/antd/src/OneOfAnt.tsx
+++ b/packages/antd/src/OneOfAnt.tsx
@@ -31,7 +31,10 @@ export interface OneOfAntProps {
 @observer
 export class OneOfAnt extends React.Component<BindAntProps<OneOf> & RadioProps & RadioGroupProps & OneOfAntProps> {
     render() {
-        const { operation, invisible, vertical, breakAfter, ...props } = parseProps(this.props, this.props.operation);
+        const { operation, invisible, vertical, breakAfter, reason, ...props } = parseProps(
+            this.props,
+            this.props.operation
+        );
         if (invisible) {
             return null;
         }
@@ -56,14 +59,16 @@ export class OneOfAnt extends React.Component<BindAntProps<OneOf> & RadioProps &
             }
         });
         return (
-            <Radio.Group
-                data-testid={idToDomId(operation.id)}
-                onChange={(e) => operation.setValue(e.target.value)}
-                {...props}
-                value={operation.value}
-            >
-                {elements}
-            </Radio.Group>
+            <span title={reason}>
+                <Radio.Group
+                    data-testid={idToDomId(operation.id)}
+                    onChange={(e) => operation.setValue(e.target.value)}
+                    {...props}
+                    value={operation.value}
+                >
+                    {elements}
+                </Radio.Group>
+            </span>
         );
     }
 }
@@ -99,7 +104,10 @@ export class OneOfButtonAnt extends React.Component<
     BindAntProps<OneOf> & RadioProps & RadioGroupProps & OneOfButtonAntProps
 > {
     render() {
-        const { operation, invisible, readOnly, breakAfter, ...props } = parseProps(this.props, this.props.operation);
+        const { operation, invisible, readOnly, breakAfter, reason, ...props } = parseProps(
+            this.props,
+            this.props.operation
+        );
         if (invisible) {
             return null;
         }
@@ -119,14 +127,16 @@ export class OneOfButtonAnt extends React.Component<
         });
 
         return (
-            <Radio.Group
-                data-testid={operation.id}
-                onChange={(e) => operation.setValue(e.target.value)}
-                {...props}
-                value={operation.value}
-            >
-                {elements}
-            </Radio.Group>
+            <span title={reason}>
+                <Radio.Group
+                    data-testid={operation.id}
+                    onChange={(e) => operation.setValue(e.target.value)}
+                    {...props}
+                    value={operation.value}
+                >
+                    {elements}
+                </Radio.Group>
+            </span>
         );
     }
 }
@@ -239,7 +249,7 @@ export class OneOfDropDownFormAnt extends React.Component<
 @observer
 export class OneOfSelectAnt extends React.Component<BindAntProps<OneOf> & SelectProps<any>> {
     render() {
-        const { operation, invisible, readOnly, mode, ...props } = parseProps(this.props, this.props.operation);
+        const { operation, invisible, readOnly, mode, reason, ...props } = parseProps(this.props, this.props.operation);
         if (invisible) {
             return null;
         }
@@ -248,24 +258,26 @@ export class OneOfSelectAnt extends React.Component<BindAntProps<OneOf> & Select
         }
 
         return (
-            <Select
-                data-testid={operation.id}
-                onChange={(selectionValue: any) => operation.setValue(selectionValue)}
-                value={operation.value || undefined}
-                placeholder={operation.placeholder}
-                mode={mode}
-                {...props}
-            >
-                {operation.choices.map((opt) => (
-                    <Select.Option
-                        data-testid={idToDomId(operation.id + '.' + opt.value)}
-                        key={opt.value}
-                        value={opt.value}
-                    >
-                        {opt.widget ? opt.widget : opt.label}
-                    </Select.Option>
-                ))}
-            </Select>
+            <span title={reason}>
+                <Select
+                    data-testid={operation.id}
+                    onChange={(selectionValue: any) => operation.setValue(selectionValue)}
+                    value={operation.value || undefined}
+                    placeholder={operation.placeholder}
+                    mode={mode}
+                    {...props}
+                >
+                    {operation.choices.map((opt) => (
+                        <Select.Option
+                            data-testid={idToDomId(operation.id + '.' + opt.value)}
+                            key={opt.value}
+                            value={opt.value}
+                        >
+                            {opt.widget ? opt.widget : opt.label}
+                        </Select.Option>
+                    ))}
+                </Select>
+            </span>
         );
     }
 }
@@ -281,7 +293,7 @@ export class OneOfSearchableSelectAnt extends React.Component<
     OneOfSearchableSelectAntState<any>
 > {
     render() {
-        const { operation, invisible, readOnly, mode, ...props } = parseProps(this.props, this.props.operation);
+        const { operation, invisible, readOnly, mode, reason, ...props } = parseProps(this.props, this.props.operation);
 
         if (invisible) {
             return null;
@@ -290,33 +302,35 @@ export class OneOfSearchableSelectAnt extends React.Component<
             return <span data-testid={operation.id}>{operation.choice}</span>;
         }
         return (
-            <Select
-                showSearch
-                defaultActiveFirstOption={false}
-                showArrow={false}
-                data-testid={operation.id}
-                onChange={(selectionValue: any) => {
-                    operation.setValue(selectionValue);
-                    operation.searchData('');
-                }}
-                onSearch={operation.searchData}
-                notFoundContent={null}
-                filterOption={false}
-                // mode={mode}
-                value={operation.value || undefined}
-                placeholder={operation.placeholder}
-                {...props}
-            >
-                {operation.filteredChoices.map((opt: BindOneOfChoice<any>) => (
-                    <Select.Option
-                        data-testid={idToDomId(operation.id + '.' + opt.value)}
-                        key={opt.value}
-                        value={opt.value}
-                    >
-                        {opt.widget ? opt.widget : opt.label}
-                    </Select.Option>
-                ))}
-            </Select>
+            <span title={reason}>
+                <Select
+                    showSearch
+                    defaultActiveFirstOption={false}
+                    showArrow={false}
+                    data-testid={operation.id}
+                    onChange={(selectionValue: any) => {
+                        operation.setValue(selectionValue);
+                        operation.searchData('');
+                    }}
+                    onSearch={operation.searchData}
+                    notFoundContent={null}
+                    filterOption={false}
+                    // mode={mode}
+                    value={operation.value || undefined}
+                    placeholder={operation.placeholder}
+                    {...props}
+                >
+                    {operation.filteredChoices.map((opt: BindOneOfChoice<any>) => (
+                        <Select.Option
+                            data-testid={idToDomId(operation.id + '.' + opt.value)}
+                            key={opt.value}
+                            value={opt.value}
+                        >
+                            {opt.widget ? opt.widget : opt.label}
+                        </Select.Option>
+                    ))}
+                </Select>
+            </span>
         );
     }
 }

--- a/packages/antd/src/SliderAnt.tsx
+++ b/packages/antd/src/SliderAnt.tsx
@@ -32,13 +32,13 @@ export class SliderAnt extends React.Component<SliderAntProps> {
     }
 
     render() {
-        const { operation, invisible, showNumber = false } = parseProps(this.props, this.props.operation);
+        const { operation, invisible, showNumber = false, reason } = parseProps(this.props, this.props.operation);
         if (invisible) {
             return null;
         }
         const formatter = (value?: number | string) => (operation.unit ? `${value}${operation.unit}` : `${value}`);
         return showNumber ? (
-            <Row>
+            <Row title={reason}>
                 <Col span={2}>
                     <span style={{ marginRight: '1em' }}>{formatter(operation.value)}</span>
                 </Col>

--- a/packages/antd/src/TagAnt.tsx
+++ b/packages/antd/src/TagAnt.tsx
@@ -62,8 +62,9 @@ export class TagAnt extends React.Component<TagAntProps, TagAntState> {
 
     render() {
         const { inputVisible, inputValue } = this.state;
+
         return (
-            <div data-testid={this.props.operation.id}>
+            <div data-testid={this.props.operation.id} title={this.props.operation.reason}>
                 {this.props.operation.value!.map((tag) => (
                     <Tag
                         data-testid={tag}

--- a/packages/antd/src/TextAnt.tsx
+++ b/packages/antd/src/TextAnt.tsx
@@ -28,13 +28,17 @@ export interface BindSearchStringAntProps extends SearchProps {
 export class TextAnt extends React.Component<BindStringAntProps> {
     // tslint:disable-next-line:cyclomatic-complexity
     render() {
-        const { operation, id, inputType, value, invisible, ...props } = parseProps(this.props, this.props.operation);
+        const { operation, id, inputType, value, invisible, reason, ...props } = parseProps(
+            this.props,
+            this.props.operation
+        );
         if (invisible) {
             return null;
         }
         if ((inputType || operation.control) === 'textarea') {
             return (
                 <Input.TextArea
+                    title={reason}
                     id={id}
                     data-testid={id}
                     placeholder={operation.placeholder}
@@ -48,6 +52,7 @@ export class TextAnt extends React.Component<BindStringAntProps> {
         } else {
             return (
                 <Input
+                    title={reason}
                     id={id}
                     data-testid={id}
                     placeholder={operation.placeholder}

--- a/packages/antd/src/TimePickerAnt.tsx
+++ b/packages/antd/src/TimePickerAnt.tsx
@@ -17,18 +17,20 @@ export interface BindTimePickerAntProps extends TimePickerProps {
 @observer
 export class TimePickerAnt extends React.Component<BindTimePickerAntProps> {
     render() {
-        const { operation, invisible, ...props } = parseProps(this.props, this.props.operation);
+        const { operation, invisible, reason, ...props } = parseProps(this.props, this.props.operation);
         if (invisible) {
             return null;
         }
         return (
-            <TimePicker
-                data-testid={operation.id}
-                placeholder={operation.placeholder}
-                value={operation.value}
-                onChange={(time: moment.Moment, _timeString: string) => operation.setValue(time)}
-                {...(props as any)}
-            />
+            <span title={reason}>
+                <TimePicker
+                    data-testid={operation.id}
+                    placeholder={operation.placeholder}
+                    value={operation.value}
+                    onChange={(time: moment.Moment, _timeString: string) => operation.setValue(time)}
+                    {...(props as any)}
+                />
+            </span>
         );
     }
 }

--- a/packages/antd/src/TreeAnt.tsx
+++ b/packages/antd/src/TreeAnt.tsx
@@ -10,7 +10,7 @@ import { BindFormItemAntProps, FormItemAnt, parsePropsForChild } from './FormIte
 @observer
 export class TreeAnt extends React.Component<BindAntProps<Tree> & TreeProps> {
     render() {
-        const { operation, invisible, children, ...props } = parseProps(this.props, this.props.operation);
+        const { operation, invisible, children, reason, ...props } = parseProps(this.props, this.props.operation);
 
         if (invisible) {
             return null;
@@ -18,20 +18,22 @@ export class TreeAnt extends React.Component<BindAntProps<Tree> & TreeProps> {
 
         const value = toJS(operation.value);
         return (
-            <TreeComponent
-                checkable={true}
-                checkStrictly={operation.strictSelect || false}
-                data-testid={operation.id}
-                treeData={operation.nodes}
-                defaultExpandedKeys={operation.expandValues ? value || [] : []}
-                checkedKeys={value || []}
-                onCheck={(checkedKeys) => {
-                    operation.setValue(checkedKeys as string[]);
-                }}
-                {...props}
-            >
-                {children}
-            </TreeComponent>
+            <span title={reason}>
+                <TreeComponent
+                    checkable={true}
+                    checkStrictly={operation.strictSelect || false}
+                    data-testid={operation.id}
+                    treeData={operation.nodes}
+                    defaultExpandedKeys={operation.expandValues ? value || [] : []}
+                    checkedKeys={value || []}
+                    onCheck={(checkedKeys) => {
+                        operation.setValue(checkedKeys as string[]);
+                    }}
+                    {...props}
+                >
+                    {children}
+                </TreeComponent>
+            </span>
         );
     }
 }

--- a/packages/antd/src/__tests__/__snapshots__/BoolAnt.test.tsx.snap
+++ b/packages/antd/src/__tests__/__snapshots__/BoolAnt.test.tsx.snap
@@ -1,16 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`BoolAnt should render a checkbox by default 1`] = `
-<Checkbox
-  data-testid="TheId"
-  disabled={false}
-  id="the_id"
-  indeterminate={true}
-  onChange={[Function]}
-  readOnly={false}
->
-  oh
-</Checkbox>
+<span>
+  <Checkbox
+    data-testid="TheId"
+    disabled={false}
+    id="the_id"
+    indeterminate={true}
+    onChange={[Function]}
+    readOnly={false}
+  >
+    oh
+  </Checkbox>
+</span>
 `;
 
 exports[`BoolFormAnt should render a checkbox by default 1`] = `

--- a/packages/antd/src/__tests__/__snapshots__/DatePickerAnt.test.tsx.snap
+++ b/packages/antd/src/__tests__/__snapshots__/DatePickerAnt.test.tsx.snap
@@ -1,14 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DatePickerAnt should render a date picker by default 1`] = `
-<Picker
-  data-testid="TheId"
-  disabled={false}
-  id="the_id"
-  label="oh"
-  onChange={[Function]}
-  readOnly={false}
-/>
+<span>
+  <Picker
+    data-testid="TheId"
+    disabled={false}
+    id="the_id"
+    label="oh"
+    onChange={[Function]}
+    readOnly={false}
+  />
+</span>
 `;
 
 exports[`DatePickerFormAnt should render form item with a date picker by default 1`] = `

--- a/packages/antd/src/__tests__/__snapshots__/ManyOfAnt.test.tsx.snap
+++ b/packages/antd/src/__tests__/__snapshots__/ManyOfAnt.test.tsx.snap
@@ -1,41 +1,43 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ManyOfAnt should render a select control by default 1`] = `
-<Select
-  bordered={true}
-  choiceTransitionName="zoom"
-  data-testid="Id.manyOf"
-  disabled={false}
-  id="id-many_of"
-  label="Choose your snack"
-  onChange={[Function]}
-  placeholder="Please select"
-  readOnly={false}
-  transitionName="slide-up"
-  value={Array []}
->
-  <Option
-    data-testid="id-many_of-b"
-    key="b"
-    value="b"
+<span>
+  <Select
+    bordered={true}
+    choiceTransitionName="zoom"
+    data-testid="Id.manyOf"
+    disabled={false}
+    id="id-many_of"
+    label="Choose your snack"
+    onChange={[Function]}
+    placeholder="Please select"
+    readOnly={false}
+    transitionName="slide-up"
+    value={Array []}
   >
-    Banana
-  </Option>
-  <Option
-    data-testid="id-many_of-a"
-    key="a"
-    value="a"
-  >
-    Apples
-  </Option>
-  <Option
-    data-testid="id-many_of-p"
-    key="p"
-    value="p"
-  >
-    Peaches
-  </Option>
-</Select>
+    <Option
+      data-testid="id-many_of-b"
+      key="b"
+      value="b"
+    >
+      Banana
+    </Option>
+    <Option
+      data-testid="id-many_of-a"
+      key="a"
+      value="a"
+    >
+      Apples
+    </Option>
+    <Option
+      data-testid="id-many_of-p"
+      key="p"
+      value="p"
+    >
+      Peaches
+    </Option>
+  </Select>
+</span>
 `;
 
 exports[`ManyOfCheckboxAnt should render a checkboxes by default 1`] = `

--- a/packages/antd/src/__tests__/__snapshots__/OneOfAnt.test.tsx.snap
+++ b/packages/antd/src/__tests__/__snapshots__/OneOfAnt.test.tsx.snap
@@ -1,42 +1,44 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OneOfAnt should render a radio button group by default 1`] = `
-<Memo(RadioGroup)
-  data-testid="id-test_radio_of_one"
-  disabled={false}
-  id="id-test_radio_of_one"
-  label="Select one of"
-  onChange={[Function]}
-  readOnly={false}
->
-  <Radio
-    data-testid="id-test_radio_of_one-b"
-    key="b"
-    style={Object {}}
-    type="radio"
-    value="b"
+<span>
+  <Memo(RadioGroup)
+    data-testid="id-test_radio_of_one"
+    disabled={false}
+    id="id-test_radio_of_one"
+    label="Select one of"
+    onChange={[Function]}
+    readOnly={false}
   >
-    Banana
-  </Radio>
-  <Radio
-    data-testid="id-test_radio_of_one-a"
-    key="a"
-    style={Object {}}
-    type="radio"
-    value="a"
-  >
-    Apples
-  </Radio>
-  <Radio
-    data-testid="id-test_radio_of_one-p"
-    key="p"
-    style={Object {}}
-    type="radio"
-    value="p"
-  >
-    Peaches
-  </Radio>
-</Memo(RadioGroup)>
+    <Radio
+      data-testid="id-test_radio_of_one-b"
+      key="b"
+      style={Object {}}
+      type="radio"
+      value="b"
+    >
+      Banana
+    </Radio>
+    <Radio
+      data-testid="id-test_radio_of_one-a"
+      key="a"
+      style={Object {}}
+      type="radio"
+      value="a"
+    >
+      Apples
+    </Radio>
+    <Radio
+      data-testid="id-test_radio_of_one-p"
+      key="p"
+      style={Object {}}
+      type="radio"
+      value="p"
+    >
+      Peaches
+    </Radio>
+  </Memo(RadioGroup)>
+</span>
 `;
 
 exports[`OneOfDropDownAnt should render a dropdown control 1`] = `
@@ -131,39 +133,41 @@ exports[`OneOfFormAnt should render a radio button group with form by default 1`
 `;
 
 exports[`OneOfSelectAnt should render a select control 1`] = `
-<Select
-  bordered={true}
-  choiceTransitionName="zoom"
-  data-testid="id.testSelectOfOne"
-  disabled={false}
-  id="id-test_select_of_one"
-  label="Select one of"
-  onChange={[Function]}
-  placeholder="..."
-  transitionName="slide-up"
->
-  <Option
-    data-testid="id-test_select_of_one-b"
-    key="b"
-    value="b"
+<span>
+  <Select
+    bordered={true}
+    choiceTransitionName="zoom"
+    data-testid="id.testSelectOfOne"
+    disabled={false}
+    id="id-test_select_of_one"
+    label="Select one of"
+    onChange={[Function]}
+    placeholder="..."
+    transitionName="slide-up"
   >
-    Banana
-  </Option>
-  <Option
-    data-testid="id-test_select_of_one-a"
-    key="a"
-    value="a"
-  >
-    Apples
-  </Option>
-  <Option
-    data-testid="id-test_select_of_one-p"
-    key="p"
-    value="p"
-  >
-    Peaches
-  </Option>
-</Select>
+    <Option
+      data-testid="id-test_select_of_one-b"
+      key="b"
+      value="b"
+    >
+      Banana
+    </Option>
+    <Option
+      data-testid="id-test_select_of_one-a"
+      key="a"
+      value="a"
+    >
+      Apples
+    </Option>
+    <Option
+      data-testid="id-test_select_of_one-p"
+      key="p"
+      value="p"
+    >
+      Peaches
+    </Option>
+  </Select>
+</span>
 `;
 
 exports[`OneOfSelectFormAnt should render a select control with form 1`] = `

--- a/packages/antd/src/__tests__/__snapshots__/TimePickerAnt.test.tsx.snap
+++ b/packages/antd/src/__tests__/__snapshots__/TimePickerAnt.test.tsx.snap
@@ -1,14 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TimePickerAnt should render a time picker by default 1`] = `
-<TimePicker
-  data-testid="TheId"
-  disabled={false}
-  id="the_id"
-  label="oh"
-  onChange={[Function]}
-  readOnly={false}
-/>
+<span>
+  <TimePicker
+    data-testid="TheId"
+    disabled={false}
+    id="the_id"
+    label="oh"
+    onChange={[Function]}
+    readOnly={false}
+  />
+</span>
 `;
 
 exports[`TimePickerFormAnt should render form item with a time picker by default 1`] = `

--- a/packages/antd/src/routing/NavLinkButtonAnt.tsx
+++ b/packages/antd/src/routing/NavLinkButtonAnt.tsx
@@ -70,7 +70,7 @@ export class NavLinkButtonAnt extends React.Component<NavLinkButtonAntProps & Us
             // When the link target is set, we don't want to use a button for the navigation.
             // Instead, we will use a real HTML link on the button, and let the browser
             // handle the actual navigation step. (Which will open a new tab anyway.)
-            const { to, position, appendTokens, removeTokenCount, argChanges, toRef, disabled } = this.props;
+            const { to, position, appendTokens, removeTokenCount, argChanges, toRef } = this.props;
             return (
                 <Button data-testid={url} {...(extraButtonProps as any)} {...buttonProps}>
                     <NavLink

--- a/packages/moxb/src/many-of/ManyOf.ts
+++ b/packages/moxb/src/many-of/ManyOf.ts
@@ -11,4 +11,6 @@ export interface BindManyOfChoice<T = string> {
 export interface ManyOf<T = string> extends Value<T[]> {
     readonly choices: BindManyOfChoice<T>[];
     readonly verticalDisplay?: boolean;
+    isSelected(choice: T): boolean;
+    toggle(choice: T): void;
 }

--- a/packages/moxb/src/many-of/ManyOf.ts
+++ b/packages/moxb/src/many-of/ManyOf.ts
@@ -10,7 +10,6 @@ export interface BindManyOfChoice<T = string> {
 
 export interface ManyOf<T = string> extends Value<T[]> {
     readonly choices: BindManyOfChoice<T>[];
-    readonly verticalDisplay?: boolean;
     isSelected(choice: T): boolean;
     toggle(choice: T): void;
 }

--- a/packages/moxb/src/many-of/ManyOfImpl.ts
+++ b/packages/moxb/src/many-of/ManyOfImpl.ts
@@ -31,4 +31,18 @@ export class ManyOfImpl<T = string> extends ValueImpl<ManyOfImpl, T[], ManyOfOpt
             return this.impl.verticalDisplay || false;
         }
     }
+
+    isSelected(choice: T): boolean {
+        return !!this.value && this.value.indexOf(choice) !== -1;
+    }
+
+    toggle(choice: T) {
+        if (this.isSelected(choice)) {
+            // Un-select this
+            this.setValue(this.value!.filter((c) => c !== choice));
+        } else {
+            // Select this
+            this.setValue([...(this.value || []), choice]);
+        }
+    }
 }

--- a/packages/moxb/src/many-of/ManyOfImpl.ts
+++ b/packages/moxb/src/many-of/ManyOfImpl.ts
@@ -6,7 +6,6 @@ import { BindManyOfChoice, ManyOf } from './ManyOf';
 
 export interface ManyOfOptions<T> extends ValueOptions<ManyOfImpl, T[]> {
     choices?: ValueOrFunction<BindOneOfChoice<T>[]>;
-    verticalDisplay?: ValueOrFunction<boolean>;
 }
 
 export class ManyOfImpl<T = string> extends ValueImpl<ManyOfImpl, T[], ManyOfOptions<T>> implements ManyOf<T> {
@@ -20,15 +19,6 @@ export class ManyOfImpl<T = string> extends ValueImpl<ManyOfImpl, T[], ManyOfOpt
             return this.impl.choices() || [];
         } else {
             return this.impl.choices || [];
-        }
-    }
-
-    @computed
-    get verticalDisplay(): boolean {
-        if (typeof this.impl.verticalDisplay === 'function') {
-            return this.impl.verticalDisplay() || false;
-        } else {
-            return this.impl.verticalDisplay || false;
         }
     }
 


### PR DESCRIPTION
Many small improvements in the input widgets.

The outline:
 - Make sure to always properly indicate the disabled state, and preferably also the reason
 - Make sure to always display the help messages for choices (on OneOf / ManyOf), whenever possible
 - ManyOf: add functions to test/set the selection status of the individual choices
 - Add ManyOfSwitchAnt (a multi-select widget based on switches)

Please see the individual commit messages for details.