### PR TITLE
Revert to the browser's native title feature for a uniform look

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,9 @@ Follow the principles in [keepachangelog.com](https://keepachangelog.com)!
 
 # v.Next (Current)
 
+### Changed
+ - Revert to the browser's native title feature, instead of the ant tooltip
+
 # [v0.2.0-beta.70](https://github.com/moxb/moxb/releases/tag/v0.2.0-beta.70) (2021-02-20)
 
 ### Added

--- a/packages/antd/src/BindAnt.tsx
+++ b/packages/antd/src/BindAnt.tsx
@@ -39,8 +39,9 @@ export function parseProps<T, O>(bindProps: T, _op: O): T & O {
 }
 
 /**
- * Create a HTML SPAN that can be used as a label, with an optional popup help, and a ? for indicator.
+ * Create a HTML SPAN that can be used as a label, with an optional tooltip, and a ? for indicator.
  */
+/** @deprecated since version v0.2.0-beta.70 */
 export function labelWithHelp(label: any, help?: string, id?: string) {
     if (help && typeof label === 'string') {
         return (
@@ -65,6 +66,21 @@ export function labelWithHelpIndicator(label: any, help?: string) {
     if (help && typeof label === 'string') {
         return (
             <span>
+                {label} <QuestionCircleOutlined />
+            </span>
+        );
+    } else {
+        return label;
+    }
+}
+
+/**
+ * Create a HTML SPAN that can be used as a label, with an optional title, and a ? for indicator.
+ */
+export function labelWithHelpSpan(label: any, help?: string, id?: string) {
+    if (help && typeof label === 'string') {
+        return (
+            <span data-testid={id + '-help-label'} title={help}>
                 {label} <QuestionCircleOutlined />
             </span>
         );

--- a/packages/antd/src/BoolAnt.tsx
+++ b/packages/antd/src/BoolAnt.tsx
@@ -5,7 +5,7 @@ import { SwitchSize } from 'antd/lib/switch';
 import { FormItemProps } from 'antd/lib/form/FormItem';
 import { observer } from 'mobx-react';
 import * as React from 'react';
-import { BindAntProps, labelWithHelp, parseProps } from './BindAnt';
+import { BindAntProps, labelWithHelpIndicator, parseProps } from './BindAnt';
 import { FormItemAnt, parsePropsForChild } from './FormItemAnt';
 
 @observer
@@ -21,7 +21,7 @@ export class BoolAnt extends React.Component<BindAntProps<Bool> & CheckboxProps>
         // a null value renders the checkbox in intermediate state!
         const indeterminate = operation.value == null;
         return (
-            <span title={reason}>
+            <span title={reason || operation.help}>
                 <Checkbox
                     data-testid={operation.id}
                     checked={operation.value}
@@ -30,7 +30,7 @@ export class BoolAnt extends React.Component<BindAntProps<Bool> & CheckboxProps>
                     {...props}
                 >
                     {children}
-                    {labelWithHelp(label, operation.help, operation.id)}
+                    {labelWithHelpIndicator(label, operation.help)}
                 </Checkbox>
             </span>
         );
@@ -60,7 +60,7 @@ export class BoolSwitchAnt extends React.Component<BindAntProps<Bool> & AllowedS
         const switchClassName = disabled ? 'ant-checkbox-disabled' : '';
         const labelClassName = disabled ? '' : 'ant-checkbox-wrapper';
         return (
-            <span title={reason}>
+            <span title={reason || operation.help}>
                 <span className={switchClassName}>
                     <Switch
                         disabled={disabled}
@@ -72,7 +72,7 @@ export class BoolSwitchAnt extends React.Component<BindAntProps<Bool> & AllowedS
                 </span>
                 &nbsp; &nbsp;
                 <span onClick={() => operation.toggle()} className={labelClassName}>
-                    {labelWithHelp(label, operation.help, operation.id)}
+                    {labelWithHelpIndicator(label, operation.help)}
                 </span>
             </span>
         );

--- a/packages/antd/src/FormItemAnt.tsx
+++ b/packages/antd/src/FormItemAnt.tsx
@@ -5,7 +5,7 @@ import { ColProps } from 'antd/lib/grid';
 import { observer } from 'mobx-react';
 import * as React from 'react';
 import { CSSProperties } from 'react';
-import { getErrorMessages, labelWithHelp, parseProps } from './BindAnt';
+import { getErrorMessages, labelWithHelpSpan, parseProps } from './BindAnt';
 import { BindMarkdownDiv } from './LabelAnt';
 
 // Due to the recent antd changes the children property in the FormItemProps component
@@ -44,7 +44,7 @@ export class FormItemAnt extends React.Component<BindFormItemAntProps> {
             <Form.Item
                 htmlFor={fullId}
                 data-testid={fullId}
-                label={labelWithHelp(label, help, fullId)}
+                label={labelWithHelpSpan(label, help)}
                 style={formStyle || undefined}
                 extra={extraLabel}
                 labelCol={labelCol}


### PR DESCRIPTION
…instead of using a custom tooltip.

We used this tooltip for display various help messages.
But in some situations this doesn't work, so in those cases we used the browser's title attribute.
In the end we had a mixture of the two.

It seemed to be OK, but it turns out, that it some browsers the two thing looks quite differently,
which is confusing. So this PR deprecates the tooltip-based feature, and stops using it in widgets.

I haven't covered the Semantic UI widgets, because we don't really maintain them anyway.