### PR TITLE
Adjusted message priorities on OneOfAnt and OneOfButtonAnt

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,10 @@
 
 Follow the principles in [keepachangelog.com](https://keepachangelog.com)!
 
+# Next version
+
+### Fixed
+ - Adjusted message priorities on OneOfAnt and OneOfButtonAnt
 
 # [v0.2.0-beta.73](https://github.com/moxb/moxb/releases/tag/v0.2.0-beta.73) (2021-02-26)
 

--- a/packages/antd/src/OneOfAnt.tsx
+++ b/packages/antd/src/OneOfAnt.tsx
@@ -45,7 +45,7 @@ export class OneOfAnt extends React.Component<BindAntProps<OneOf> & RadioProps &
         const elements: JSX.Element[] = [];
         operation.choices.forEach((opt, index) => {
             elements.push(
-                <span key={opt.value} title={opt.reason || opt.help}>
+                <span key={opt.value} title={reason || opt.reason || opt.help}>
                     <Radio
                         data-testid={idToDomId(operation.id + '.' + opt.value)}
                         key={opt.value}
@@ -62,16 +62,14 @@ export class OneOfAnt extends React.Component<BindAntProps<OneOf> & RadioProps &
             }
         });
         return (
-            <span title={reason}>
-                <Radio.Group
-                    data-testid={idToDomId(operation.id)}
-                    onChange={(e) => operation.setValue(e.target.value)}
-                    {...props}
-                    value={operation.value}
-                >
-                    {elements}
-                </Radio.Group>
-            </span>
+            <Radio.Group
+                data-testid={idToDomId(operation.id)}
+                onChange={(e) => operation.setValue(e.target.value)}
+                {...props}
+                value={operation.value}
+            >
+                {elements}
+            </Radio.Group>
         );
     }
 }
@@ -120,7 +118,7 @@ export class OneOfButtonAnt extends React.Component<
         const elements: JSX.Element[] = [];
         operation.choices.forEach((opt, index) => {
             elements.push(
-                <span key={opt.value} title={opt.reason || opt.help}>
+                <span key={opt.value} title={reason || opt.reason || opt.help}>
                     <Radio.Button
                         data-testid={idToDomId(operation.id + '.' + opt.value)}
                         key={opt.value}
@@ -137,16 +135,14 @@ export class OneOfButtonAnt extends React.Component<
         });
 
         return (
-            <span title={reason}>
-                <Radio.Group
-                    data-testid={operation.id}
-                    onChange={(e) => operation.setValue(e.target.value)}
-                    {...props}
-                    value={operation.value}
-                >
-                    {elements}
-                </Radio.Group>
-            </span>
+            <Radio.Group
+                data-testid={operation.id}
+                onChange={(e) => operation.setValue(e.target.value)}
+                {...props}
+                value={operation.value}
+            >
+                {elements}
+            </Radio.Group>
         );
     }
 }

--- a/packages/antd/src/__tests__/__snapshots__/OneOfAnt.test.tsx.snap
+++ b/packages/antd/src/__tests__/__snapshots__/OneOfAnt.test.tsx.snap
@@ -1,56 +1,54 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OneOfAnt should render a radio button group by default 1`] = `
-<span>
-  <Memo(RadioGroup)
-    data-testid="id-test_radio_of_one"
-    disabled={false}
-    id="id-test_radio_of_one"
-    label="Select one of"
-    onChange={[Function]}
-    readOnly={false}
+<Memo(RadioGroup)
+  data-testid="id-test_radio_of_one"
+  disabled={false}
+  id="id-test_radio_of_one"
+  label="Select one of"
+  onChange={[Function]}
+  readOnly={false}
+>
+  <span
+    key="b"
   >
-    <span
+    <Radio
+      data-testid="id-test_radio_of_one-b"
       key="b"
+      style={Object {}}
+      type="radio"
+      value="b"
     >
-      <Radio
-        data-testid="id-test_radio_of_one-b"
-        key="b"
-        style={Object {}}
-        type="radio"
-        value="b"
-      >
-        Banana
-      </Radio>
-    </span>
-    <span
+      Banana
+    </Radio>
+  </span>
+  <span
+    key="a"
+  >
+    <Radio
+      data-testid="id-test_radio_of_one-a"
       key="a"
+      style={Object {}}
+      type="radio"
+      value="a"
     >
-      <Radio
-        data-testid="id-test_radio_of_one-a"
-        key="a"
-        style={Object {}}
-        type="radio"
-        value="a"
-      >
-        Apples
-      </Radio>
-    </span>
-    <span
+      Apples
+    </Radio>
+  </span>
+  <span
+    key="p"
+  >
+    <Radio
+      data-testid="id-test_radio_of_one-p"
       key="p"
+      style={Object {}}
+      type="radio"
+      value="p"
     >
-      <Radio
-        data-testid="id-test_radio_of_one-p"
-        key="p"
-        style={Object {}}
-        type="radio"
-        value="p"
-      >
-        Peaches
-      </Radio>
-    </span>
-  </Memo(RadioGroup)>
-</span>
+      Peaches
+    </Radio>
+  </span>
+</Memo(RadioGroup)>
 `;
 
 exports[`OneOfDropDownAnt should render a dropdown control 1`] = `


### PR DESCRIPTION
When there is a OneOf or ManyOf widget, it's possible that there are multiple messages
that could be displayed at the same time:
 - Help text for the individual choices
 - The reason by a choice is disabled
 - The reason why the whole widget is disabled.

Make sure that we display the messages according to the correct priorities.