### PR TITLE
Fix handling non-integer values for NumericAnt

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,8 @@ Follow the principles in [keepachangelog.com](https://keepachangelog.com)!
 
 # Next version
 
+### Fixed
+- Handle non-integer steps for NumericAnt
 
 # [v0.2.0-beta.74](https://github.com/moxb/moxb/releases/tag/v0.2.0-beta.74) (2021-03-13)
 

--- a/packages/antd/src/NumericAnt.tsx
+++ b/packages/antd/src/NumericAnt.tsx
@@ -14,9 +14,15 @@ export class NumericAnt extends React.Component<BindAntProps<Numeric> & InputNum
         if (invisible) {
             return null;
         }
-        const formatter = (value?: number | string) => (operation.unit ? `${value}${operation.unit}` : `${value}`);
-        const parser = (value?: string) =>
-            operation.unit ? parseInt(value!.replace(`${operation.unit}`, '') || '0') : parseInt(value || '0');
+
+        const formatter = operation.unit ? (value?: number | string) => `${value}${operation.unit}` : undefined;
+        const parser = operation.unit
+            ? (value?: string) =>
+                  operation.step && !Number.isInteger(operation.step)
+                      ? parseFloat(value!.replace(`${operation.unit}`, '') || '0')
+                      : parseInt(value!.replace(`${operation.unit}`, '') || '0')
+            : undefined;
+
         return (
             <InputNumber
                 title={reason}
@@ -31,7 +37,12 @@ export class NumericAnt extends React.Component<BindAntProps<Numeric> & InputNum
                 formatter={formatter}
                 parser={parser}
                 onChange={(value) => {
-                    operation.setValue(parseInt(value ? value + '' : '0'));
+                    const newValue = value
+                        ? operation.step && !Number.isInteger(operation.step)
+                            ? parseFloat(value + '')
+                            : parseInt(value + '')
+                        : 0;
+                    operation.setValue(newValue);
                     operation.onExitField();
                 }}
                 {...props}

--- a/packages/antd/src/__tests__/__snapshots__/NumericAnt.test.tsx.snap
+++ b/packages/antd/src/__tests__/__snapshots__/NumericAnt.test.tsx.snap
@@ -4,11 +4,9 @@ exports[`NumericAnt should render a numeric input by default 1`] = `
 <ForwardRef
   data-testid="TheId"
   disabled={false}
-  formatter={[Function]}
   id="the_id"
   label="oh"
   onChange={[Function]}
-  parser={[Function]}
   placeholder="Interval"
   readOnly={false}
   step={1}


### PR DESCRIPTION
The model and the antd inputnumber component are prepared to handle non-integer values
with a fixed precision. But our NumericAnt parse functions didn't take this into consideration.
This restores that functionality