### PR TITLE
Small navigation improvements / fixes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,8 +1,12 @@
+
 # Change Log
 
 Follow the principles in [keepachangelog.com](https://keepachangelog.com)!
 
 # Next version
+
+### Added
+- Added (and changed) some more methods on LocationManager
 
 # [v0.2.0-beta.75](https://github.com/moxb/moxb/releases/tag/v0.2.0-beta.75) (2021-03-26)
 

--- a/packages/moxb/src/routing/TokenManagerImpl.ts
+++ b/packages/moxb/src/routing/TokenManagerImpl.ts
@@ -563,7 +563,7 @@ export class TokenManagerImpl implements TokenManager {
         }
 
         // These are the tokens on the current path that we can work with
-        const localTokens = this._locationManager.pathTokens.slice(parsedTokens);
+        const localTokens = this._locationManager.getPathTokensForLocation(prevLocation).slice(parsedTokens);
 
         // Let's see if we can reach the wanted mapping
         let tokenIndex = 0; // let's count which element of the current path we are looking at

--- a/packages/moxb/src/routing/index.ts
+++ b/packages/moxb/src/routing/index.ts
@@ -6,6 +6,7 @@ export {
     QueryChange,
     BasicLocationManagerImpl,
     locationToUrl,
+    urlToLocation,
     pathAndQueryToLocation,
     pathAndQueryToUrl,
 } from './location-manager';

--- a/packages/moxb/src/routing/location-manager/LocationManager.ts
+++ b/packages/moxb/src/routing/location-manager/LocationManager.ts
@@ -73,7 +73,7 @@ export interface TestLocation {
      * @param level The level where the token should be found
      * @param exactOnly Is it a match only if there are no further tokens?
      */
-    doPathTokensMatch: (token: string[], level: number, exactOnly: boolean, debugMode?: boolean) => boolean;
+    doPathTokensMatch?: (token: string[], level: number, exactOnly: boolean, debugMode?: boolean) => boolean;
 
     /**
      * the search queries for the current location
@@ -146,6 +146,11 @@ export interface LocationManager {
      * path tokens for the current location
      */
     readonly pathTokens: string[];
+
+    /**
+     * Get the path tokens for a given location
+     */
+    getPathTokensForLocation(location: MyLocation): string[];
 
     /**
      * Determine whether a given token at a given level matches
@@ -222,6 +227,11 @@ export interface LocationManager {
      * the search queries for the current location
      */
     readonly query: Query;
+
+    /**
+     * the search queries for a given location
+     */
+    getQueryForLocation(location: MyLocation): Query;
 
     /**
      * Determine the URL that we would get if we changed some URL arguments
@@ -320,13 +330,17 @@ export interface LocationManager {
         baseLocation: MyLocation | undefined,
         position: number | undefined,
         tokens: string[] | undefined,
-        queryChanges: QueryChange[] | undefined
+        queryChanges: QueryChange[] | undefined,
+        dropPermanent?: boolean
     ) => MyLocation;
 
     /**
      * Calculate what would be the new location, if a given link were to be used
+     *
+     * dropPermanent means that calculating such a way that we drop even the normally
+     * retained permanent url arguments, too
      */
-    getNewLocationForLinkProps: (link: CoreLinkProps) => MyLocation;
+    getNewLocationForLinkProps: (link: CoreLinkProps, dropPermanent?: boolean) => MyLocation;
 
     /**
      * Determine the URL that we would get if we changed the path and also some URL arguments

--- a/packages/moxb/src/routing/location-manager/index.ts
+++ b/packages/moxb/src/routing/location-manager/index.ts
@@ -9,6 +9,7 @@ export {
 export {
     BasicLocationManagerImpl,
     locationToUrl,
+    urlToLocation,
     pathAndQueryToLocation,
     pathAndQueryToUrl,
 } from './BasicLocationManagerImpl';


### PR DESCRIPTION
Interface changes:

- Export new function: `urlToLocation()``
- New methods on `LocationManager`:
  - `getPathTokensForLocation()`
  - `getQueryForLocation`
- New parameters on existing methods on `LocationManager`
  - `getNewLocationForPathAndQueryChange()` now accepts `dropPermanent`
  - `getNewLocationForLinkProps()` now accepts `dropPermanent`

Internal changes:

- Relax the `TestLocation` interface
  - `doPathTokensMatch` is now optional
- In `BasicLocationManagerImpl`
  - The `getNewLocationForPathTokens()` method now expects a base location parameter
- In `TokenManagerImpl`:
  - BUGFIX: in `_getLocationForTokenChangeOnMapping()`, really observer the `prevLocation` parameter