### PR TITLE
Add support for saving path upon redirects

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,10 @@ Follow the principles in [keepachangelog.com](https://keepachangelog.com)!
 
 # Next version
 
+### Added
+- Added support for saving previous path upon executing redirects
+
+
 # [v0.2.0-beta.80](https://github.com/moxb/moxb/releases/tag/v0.2.0-beta.80) (2021-05-31)
 
 ### Changed

--- a/packages/antd/src/routing/NavLinkButtonAnt.tsx
+++ b/packages/antd/src/routing/NavLinkButtonAnt.tsx
@@ -1,7 +1,6 @@
-import { CoreLinkProps, locationToUrl, UsesLocation } from '@moxb/moxb';
+import { CoreLinkProps, locationToUrl, UsesLocation, MyLocation } from '@moxb/moxb';
 import { Button } from 'antd';
 import { ButtonProps } from 'antd/lib/button';
-import { Path as MyLocation } from 'history';
 import { inject, observer } from 'mobx-react';
 import * as React from 'react';
 import { AnchorParams } from '@moxb/html/dist/Anchor';

--- a/packages/html/src/NavLink.tsx
+++ b/packages/html/src/NavLink.tsx
@@ -1,5 +1,4 @@
-import { CoreLinkProps, locationToUrl, UsesLocation } from '@moxb/moxb';
-import { Path as MyLocation } from 'history';
+import { CoreLinkProps, locationToUrl, UsesLocation, MyLocation } from '@moxb/moxb';
 import { inject, observer } from 'mobx-react';
 import * as React from 'react';
 import * as Anchor from './Anchor';

--- a/packages/html/src/Redirect.tsx
+++ b/packages/html/src/Redirect.tsx
@@ -1,23 +1,53 @@
-import { UpdateMethod, UsesLocation, NavRef } from '@moxb/moxb';
+import { UpdateMethod, UsesLocation, NavRef, UrlArg, MyLocation } from '@moxb/moxb';
 import { inject, observer } from 'mobx-react';
 import * as React from 'react';
 
 interface RedirectProps {
     position?: number;
-    to: string[];
+
+    /**
+     * Where should be go? (List of path tokens.)
+     *
+     * Either this or location should be given.
+     */
+    to?: string[];
+
     updateMethod?: UpdateMethod;
+
+    /**
+     * If you want the original path to be saved, provide an UrlArg for that.
+     * (Note that the arg should be permanent, in order to survive the path change.)
+     */
+    pathSaveArg?: UrlArg<MyLocation | null>;
+
+    /**
+     * Are we trying to restore a saved location? Then provide that location
+     *
+     * When supplied, this will override all other values.
+     */
+    location?: MyLocation;
 }
 
 @inject('locationManager')
 @observer
 export class Redirect extends React.Component<UsesLocation & RedirectProps> {
     public componentDidMount() {
-        const { locationManager, position = 0, to, updateMethod } = this.props;
-        locationManager!.doSetPathTokens(position, to, updateMethod);
+        const { locationManager, position = 0, to, updateMethod, pathSaveArg, location } = this.props;
+        if (location) {
+            locationManager!.doSetLocation(location, UpdateMethod.REPLACE);
+            return;
+        }
+        if (pathSaveArg) {
+            pathSaveArg.doSet(locationManager!.location);
+        }
+        if (to !== undefined) {
+            // An empty list is a valid input here, so we can't simply test for falsy
+            locationManager!.doSetPathTokens(position, to, updateMethod);
+        }
     }
 
     render() {
-        return <div>Redirecting to {this.props.to.join('/')} ... </div>;
+        return <div>Redirecting ... </div>;
     }
 }
 

--- a/packages/moxb/src/routing/TokenManager.ts
+++ b/packages/moxb/src/routing/TokenManager.ts
@@ -1,5 +1,4 @@
-import { Path as MyLocation } from 'history';
-import { SuccessCallback, UpdateMethod } from './location-manager';
+import { MyLocation, SuccessCallback, UpdateMethod } from './location-manager';
 import { StateCondition, StateSpace } from './location-state-space/state-space/StateSpace';
 import { Query } from './url-schema/UrlSchema';
 import { UrlArg } from './url-arg';

--- a/packages/moxb/src/routing/TokenManagerImpl.ts
+++ b/packages/moxb/src/routing/TokenManagerImpl.ts
@@ -1,6 +1,5 @@
-import { Path as MyLocation } from 'history';
 import { action, computed, observable } from 'mobx';
-import { LocationManager, SuccessCallback, UpdateMethod } from './location-manager';
+import { MyLocation, LocationManager, SuccessCallback, UpdateMethod } from './location-manager';
 import { LocationDependentStateSpaceHandler, LocationDependentStateSpaceHandlerImpl } from './location-state-space';
 import { TokenManager, TokenMappings } from './TokenManager';
 import { isTokenEmpty } from './tokens';

--- a/packages/moxb/src/routing/index.ts
+++ b/packages/moxb/src/routing/index.ts
@@ -1,4 +1,5 @@
 export {
+    MyLocation,
     UpdateMethod,
     LocationManager,
     UsesLocation,

--- a/packages/moxb/src/routing/location-manager/BasicLocationManagerImpl.ts
+++ b/packages/moxb/src/routing/location-manager/BasicLocationManagerImpl.ts
@@ -1,9 +1,5 @@
-import {
-    createBrowserHistory,
-    History as MyHistory,
-    Path as MyLocation,
-    To as LocationDescriptorObject,
-} from 'history';
+import { LocationDescriptorObject } from '../location-manager';
+import { createBrowserHistory, History as MyHistory } from 'history';
 import { action, observable } from 'mobx';
 import { doTokenStringsMatch, updateTokenString } from '../tokens';
 import {
@@ -24,6 +20,7 @@ import { BasicLocationCommunicator } from './BasicLocationCommunicator';
 import { LocationCommunicator } from './LocationCommunicator';
 
 import {
+    MyLocation,
     LocationChangeInterceptor,
     LocationManager,
     QueryChange,

--- a/packages/moxb/src/routing/location-manager/LocationManager.ts
+++ b/packages/moxb/src/routing/location-manager/LocationManager.ts
@@ -1,4 +1,7 @@
-import { Path as MyLocation, To as LocationDescriptorObject } from 'history';
+import { Path, To } from 'history';
+export type MyLocation = Path;
+export type LocationDescriptorObject = To;
+
 import { UrlArg } from '../url-arg';
 
 import { Query, UrlSchema } from '../url-schema/UrlSchema';

--- a/packages/moxb/src/routing/location-manager/index.ts
+++ b/packages/moxb/src/routing/location-manager/index.ts
@@ -1,4 +1,6 @@
 export {
+    MyLocation,
+    LocationDescriptorObject,
     UpdateMethod,
     LocationManager,
     UsesLocation,

--- a/packages/moxb/src/routing/navigation-references/LinkGenerator.ts
+++ b/packages/moxb/src/routing/navigation-references/LinkGenerator.ts
@@ -1,10 +1,9 @@
-import { Path as MyLocation } from 'history';
 import { StateSpace } from '../location-state-space/state-space/StateSpace';
 import { CoreLinkProps } from '../linking/CoreLinkProps';
 import { UrlSchema } from '../url-schema';
 import { ValueOrFunction } from '../../bind/BindImpl';
 import { NavRefCall } from './NavRef';
-import { LocationManager, SuccessCallback, UpdateMethod } from '../location-manager';
+import { MyLocation, LocationManager, SuccessCallback, UpdateMethod } from '../location-manager';
 
 /**
  * This is the data that we need to initialize a LinkGenerator

--- a/packages/moxb/src/routing/url-arg/AnyUrlArgImpl.ts
+++ b/packages/moxb/src/routing/url-arg/AnyUrlArgImpl.ts
@@ -1,8 +1,7 @@
 import { computed } from 'mobx';
 
-import { Path as MyLocation } from 'history';
 import { ArgDefinition, ParserFunc, UrlArg } from './UrlArg';
-import { SuccessCallback, TestLocation, UpdateMethod } from '../location-manager/LocationManager';
+import { MyLocation, SuccessCallback, TestLocation, UpdateMethod } from '../location-manager/LocationManager';
 
 export interface UrlArgBackend {
     readonly rawValue: string | undefined;

--- a/packages/moxb/src/routing/url-arg/UrlArg.ts
+++ b/packages/moxb/src/routing/url-arg/UrlArg.ts
@@ -1,6 +1,5 @@
-import { SuccessCallback, UpdateMethod } from '../location-manager';
+import { MyLocation, SuccessCallback, UpdateMethod } from '../location-manager';
 import { TestLocation } from '../location-manager/LocationManager';
-import { Path as MyLocation } from 'history';
 
 export interface ParserFunc<T> {
     (formatted: string): T;

--- a/packages/moxb/src/routing/url-arg/UrlArgImpl.ts
+++ b/packages/moxb/src/routing/url-arg/UrlArgImpl.ts
@@ -1,6 +1,5 @@
 import { computed } from 'mobx';
-import { Path as MyLocation } from 'history';
-import { LocationManager, SuccessCallback, UpdateMethod } from '../location-manager';
+import { MyLocation, LocationManager, SuccessCallback, UpdateMethod } from '../location-manager';
 
 import { Query } from '../url-schema/UrlSchema';
 import { ParserFunc, UrlArg, UrlArgDefinition } from './UrlArg';

--- a/packages/moxb/src/routing/url-arg/UrlTokenImpl.ts
+++ b/packages/moxb/src/routing/url-arg/UrlTokenImpl.ts
@@ -1,6 +1,5 @@
-import { Path as MyLocation } from 'history';
 import { computed } from 'mobx';
-import { locationToUrl, SuccessCallback, UpdateMethod } from '../location-manager';
+import { MyLocation, locationToUrl, SuccessCallback, UpdateMethod } from '../location-manager';
 import { TokenManager } from '../TokenManager';
 import { Query } from '../url-schema/UrlSchema';
 import { ParserFunc, UrlArg, UrlArgDefinition } from './UrlArg';

--- a/packages/moxb/src/routing/url-schema/HashBasedUrlSchema.ts
+++ b/packages/moxb/src/routing/url-schema/HashBasedUrlSchema.ts
@@ -1,5 +1,5 @@
 const MyURI = require('urijs');
-import { Path as MyLocation } from 'history';
+import { MyLocation } from '../location-manager';
 import { Query, UrlSchema } from './UrlSchema';
 
 export interface Props {}

--- a/packages/moxb/src/routing/url-schema/NativeUrlSchema.ts
+++ b/packages/moxb/src/routing/url-schema/NativeUrlSchema.ts
@@ -1,5 +1,5 @@
 const MyURI = require('urijs');
-import { Path as MyLocation } from 'history';
+import { MyLocation } from '../location-manager';
 import { Query, UrlSchema } from './UrlSchema';
 
 /**

--- a/packages/moxb/src/routing/url-schema/QueryBasedUrlSchema.ts
+++ b/packages/moxb/src/routing/url-schema/QueryBasedUrlSchema.ts
@@ -1,5 +1,5 @@
 const MyURI = require('urijs');
-import { Path as MyLocation } from 'history';
+import { MyLocation } from '../location-manager';
 import { Query, UrlSchema } from './UrlSchema';
 
 export interface Props {

--- a/packages/moxb/src/routing/url-schema/UrlSchema.ts
+++ b/packages/moxb/src/routing/url-schema/UrlSchema.ts
@@ -1,4 +1,4 @@
-import { Path as MyLocation, To as LocationDescriptorObject } from 'history';
+import { MyLocation, LocationDescriptorObject } from '../location-manager';
 
 /**
  * A simple Map/Dict type used to represent the URL arguments.

--- a/packages/moxb/src/routing/url-schema/__tests__/HashBasedUrlSchema.test.ts
+++ b/packages/moxb/src/routing/url-schema/__tests__/HashBasedUrlSchema.test.ts
@@ -1,4 +1,4 @@
-import { Path as MyLocation } from 'history';
+import { MyLocation } from '../../location-manager';
 import { HashBasedUrlSchema } from '../HashBasedUrlSchema';
 
 describe('Hash-based URL schema', () => {

--- a/packages/moxb/src/routing/url-schema/__tests__/NativeUrlSchema.test.ts
+++ b/packages/moxb/src/routing/url-schema/__tests__/NativeUrlSchema.test.ts
@@ -1,4 +1,4 @@
-import { Path as MyLocation } from 'history';
+import { MyLocation } from '../../location-manager';
 import { NativeUrlSchema } from '../NativeUrlSchema';
 
 describe('Native URL schema', () => {

--- a/packages/moxb/src/routing/url-schema/__tests__/QueryBasedUrlSchema.test.ts
+++ b/packages/moxb/src/routing/url-schema/__tests__/QueryBasedUrlSchema.test.ts
@@ -1,4 +1,4 @@
-import { Path as MyLocation } from 'history';
+import { MyLocation } from '../../location-manager';
 import { QueryBasedUrlSchema } from '../QueryBasedUrlSchema';
 
 describe('Query-based URL schema', () => {


### PR DESCRIPTION
Two notes here:

1. This PR consists of two commits, which are orthogonal. The first one is only a refactoring; I moved the definition of a type into a single location, instead of defining it at multiple locations. This commit should be reviewed separately. The second commit implements the new feature, and in only impacts a single file.
2. This branch is not against the latest master, but against a master version before the NPM upgrade. This was necessary so that it is compatible with the latest VES code branch, which doesn't yet have the NPM upgrade. Therefore this should be rebased after that one is merged, too.