### PR TITLE
Added `ShallowStructObservable`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,10 @@ Follow the principles in [keepachangelog.com](https://keepachangelog.com)!
 
 ### Added
 - ToolTipAnt: added support for displaying the reason why it is disabled
+- Added [`ShallowStructObservable`](packages/moxb/src/util/ShallowStructObservable.ts) a helper to do to
+  combine `observable.shallow` with `observable.struct`. Useful when `observable.struct` causes too many reactions
+  and `observable` would make all children observable. It is used when new versions of a object come form a rest call or
+  a meteor subscription and you are interested in changes at the top level.
 
 # [v0.2.0-beta.83](https://github.com/moxb/moxb/releases/tag/v0.2.0-beta.83) (2021-06-01)
 

--- a/packages/moxb/src/impl.ts
+++ b/packages/moxb/src/impl.ts
@@ -28,6 +28,7 @@ export * from './util/cycle';
 export * from './util/toId';
 export * from './util/toJSON';
 export * from './util/idToDomId';
+export * from './util/ShallowStructObservable';
 export * from './i18n/i18n';
 export * from './form/FormImpl';
 export * from './keyboard-shortcuts/KeyboardShortcutsManagerImpl';

--- a/packages/moxb/src/util/ShallowStructObservable.ts
+++ b/packages/moxb/src/util/ShallowStructObservable.ts
@@ -1,0 +1,91 @@
+import { action, comparer, observable } from 'mobx';
+
+/**
+ * This class provides an observable that tracks attributes at the top level. Similar to the meteor mini mongo:
+ * When a new value is assigned, it changes only the attributes that are structurally different from the current
+ * value.
+ *
+ * For example, if your value is
+ *    `{ tilte: 'foo', numbers:[1,2,3]}`
+ * and you assign a new value
+ *     `{ tilte: 'foo', numbers:[1,2,3]}`
+ * then only `title` will trigger a change.
+ *
+ * Why is this different from `@observable.shallow`? Observable shallow is used when we assign new values to the
+ * top level attributes. But when we assign a new `value` to `@observable.shallow` then all attributes change.
+ *
+ * This wrapper checks for the structurally (not deep equal) changed attributes ond only modifies them.
+ *
+ * *Note*: The only supported way to change the object is by assigning new values using the `set` method! If a top level
+ * value is assigned then it would also work. But modifying a child object or array has no effect in reactiveness.
+ *
+ * So, the typical use is: when you get a new version of the object from the server and you want to minimize the
+ * reactions to attributes that have really changed.
+ *
+ * Given the following code where `data` gets new versions form an rest call or form a meteor subscription:
+ *
+ *      class MyClass {
+ *          @observable // or @observable.struct
+ *          data: Data;
+ *      }
+ *
+ * When new data arrives you would make a call like `myObject.data = newData`, where `newData` is a full object with
+ * all attributes.
+ *
+ * In this case the code can be replaced with this:
+ *
+ *      class MyClass {
+ *          private _data = new ShallowStructObservable<Data>();
+ *          get data() {
+ *              return this._data;
+ *          }
+ *          set data(value) {
+ *              this._data.set(value)
+ *          }
+ *      }
+ *
+ */
+export class ShallowStructObservable<T extends { [index: string]: any }> {
+    // we use shallow to trigger updates if an attribute changes
+    @observable.shallow
+    private _value?: T;
+
+    /**
+     * Assign a new version of the value.
+     *
+     * Assigns attributes only if the new version is structurally different from the current one.
+     *
+     * @param value
+     */
+    @action
+    set(value: T | undefined) {
+        if (this._value === undefined) {
+            this._value = value;
+        } else if (value === undefined) {
+            this._value = value;
+        } else {
+            // get all properties from orig and new value
+            const keys = new Set<string>();
+            Object.keys(value).forEach((k) => keys.add(k));
+            Object.keys(this._value).forEach((k) => keys.add(k));
+
+            keys.forEach((k) => {
+                if (!comparer.structural(this._value![k], value[k])) {
+                    // console.log('ASSET_CHANGED=', k);
+                    const v: any = value[k];
+                    if (v === undefined) {
+                        // delete undefined attributes from our object
+                        delete this._value![k];
+                    } else {
+                        // @ts-ignore
+                        this._value[k] = value[k];
+                    }
+                }
+            });
+        }
+    }
+
+    get(): T | undefined {
+        return this._value;
+    }
+}

--- a/packages/moxb/src/util/__tests__/ShallowStructObservable.test.ts
+++ b/packages/moxb/src/util/__tests__/ShallowStructObservable.test.ts
@@ -1,0 +1,207 @@
+import { ShallowStructObservable } from '../ShallowStructObservable';
+import { autorun, observable, runInAction, toJS } from 'mobx';
+
+describe('ShallowStructObservable', function () {
+    interface Data {
+        name: string;
+        words?: string[];
+        child?: Data;
+    }
+    it('should be undefined initially', function () {
+        const data = new ShallowStructObservable<Data>();
+        expect(data.get()).toBeUndefined();
+    });
+    it('should be the same as the set value', function () {
+        const data = new ShallowStructObservable<Data>();
+        data.set({ name: 'foo' });
+        expect(toJS(data.get())).toEqual({ name: 'foo' });
+    });
+    it('should update the value', function () {
+        const data = new ShallowStructObservable<Data>();
+        data.set({ name: 'foo' });
+        data.set({ name: 'bar' });
+        expect(toJS(data.get())).toEqual({ name: 'bar' });
+    });
+});
+describe('ShallowStructObservable reactiveness', function () {
+    interface Data {
+        name: string;
+        words?: string[];
+        child?: Data;
+    }
+    class Store {
+        @observable.shallow
+        _data = new ShallowStructObservable<Data>();
+        get data() {
+            return this._data.get();
+        }
+        set data(data) {
+            this._data.set(data);
+        }
+    }
+    function installReactions(store: Store) {
+        const changes = {
+            name: 0,
+            words: 0,
+            child: 0,
+        };
+        autorun(() => {
+            store.data?.name;
+            changes.name += 1;
+        });
+        autorun(() => {
+            store.data?.words;
+            changes.words += 1;
+        });
+        autorun(() => {
+            store.data?.child;
+            changes.child += 1;
+        });
+        return changes;
+    }
+    it('should have no reactions initially', function () {
+        const store = new Store();
+        const changes = installReactions(store);
+        expect(changes).toEqual({
+            name: 1,
+            words: 1,
+            child: 1,
+        });
+    });
+    it('should change all values when going form undefined to an object', function () {
+        const store = new Store();
+        const changes = installReactions(store);
+        store.data = { name: 'foo' };
+        expect(changes).toEqual({
+            name: 2,
+            words: 2,
+            child: 2,
+        });
+    });
+    it('should change only change the `name`', function () {
+        const store = new Store();
+        const changes = installReactions(store);
+        store.data = { name: 'foo' };
+        store.data = { name: 'bar' };
+        expect(changes).toEqual({
+            name: 3,
+            words: 2,
+            child: 2,
+        });
+    });
+    it('should change change words`', function () {
+        const store = new Store();
+        const changes = installReactions(store);
+        store.data = { name: 'foo' };
+        store.data = { ...store.data, words: ['foo', 'bar'] };
+        expect(changes).toEqual({
+            name: 2,
+            words: 3,
+            child: 2,
+        });
+    });
+    it('should change change `child`', function () {
+        const store = new Store();
+        const changes = installReactions(store);
+        store.data = { name: 'foo' };
+        store.data = { ...store.data, child: { name: 'child' } };
+        expect(changes).toEqual({
+            name: 2,
+            words: 2,
+            child: 3,
+        });
+    });
+    it('should update if all are changed', function () {
+        const store = new Store();
+        const changes = installReactions(store);
+        store.data = { name: 'foo' };
+        store.data = { name: 'updated', words: ['foo', 'bar'], child: { name: 'child' } };
+        expect(changes).toEqual({
+            name: 3,
+            words: 3,
+            child: 3,
+        });
+    });
+    it('should not fire when data inside subobjects change (DO NOT DO THIS)', function () {
+        const store = new Store();
+        const changes = installReactions(store);
+        store.data = { name: 'updated', words: ['foo', 'bar'], child: { name: 'child' } };
+        store.data.words!.push('baz');
+        store.data.child!.name = 'updated';
+        expect(changes).toEqual({
+            name: 2,
+            words: 2,
+            child: 2,
+        });
+        expect(store.data).toEqual({ name: 'updated', words: ['foo', 'bar', 'baz'], child: { name: 'updated' } });
+    });
+    it('should remove values if not set', function () {
+        const store = new Store();
+        const changes = installReactions(store);
+        store.data = { name: 'foo', words: ['foo', 'bar'], child: { name: 'child' } };
+        store.data = { name: 'foo' };
+        expect(changes).toEqual({
+            name: 2,
+            words: 3,
+            child: 3,
+        });
+        expect(store.data).toEqual({ name: 'foo' });
+    });
+    it('should set values to undefined', function () {
+        const store = new Store();
+        const changes = installReactions(store);
+        store.data = { name: 'updated', words: ['foo', 'bar'], child: { name: 'child' } };
+        store.data = undefined;
+        expect(changes).toEqual({
+            name: 3,
+            words: 3,
+            child: 3,
+        });
+        expect(store.data).toBeUndefined();
+    });
+    it('should update direct values correctly', function () {
+        const store = new Store();
+        const changes = installReactions(store);
+        store.data = { name: 'foo', words: ['foo', 'bar'], child: { name: 'child' } };
+        store.data.name = 'new name';
+        expect(changes).toEqual({
+            name: 3,
+            words: 2,
+            child: 2,
+        });
+        expect(store.data).toEqual({ name: 'new name', words: ['foo', 'bar'], child: { name: 'child' } });
+    });
+    it('should update top level changes of nested values', function () {
+        const store = new Store();
+        const changes = installReactions(store);
+        store.data = { name: 'foo', words: ['foo', 'bar'], child: { name: 'child' } };
+        store.data!.name = 'new name';
+        store.data!.words = [];
+        store.data!.child = { name: 'child', words: ['a', 'b'] };
+        expect(changes).toEqual({
+            name: 3,
+            words: 3,
+            child: 3,
+        });
+        expect(store.data).toEqual({ name: 'new name', words: [], child: { name: 'child', words: ['a', 'b'] } });
+    });
+    it('should run actions correctly', function () {
+        const store = new Store();
+        const changes = installReactions(store);
+        store.data = { name: 'foo', words: ['foo', 'bar'], child: { name: 'child' } };
+        runInAction(() => {
+            store.data!.name = 'oops';
+            store.data!.name = 'new name';
+            store.data!.words = ['xxx'];
+            store.data!.words = [];
+            store.data!.child = { ...store.data!.child!, words: [] };
+            store.data!.child = { ...store.data!.child!, words: ['a', 'b'] };
+        });
+        expect(changes).toEqual({
+            name: 3,
+            words: 3,
+            child: 3,
+        });
+        expect(store.data).toEqual({ name: 'new name', words: [], child: { name: 'child', words: ['a', 'b'] } });
+    });
+});


### PR DESCRIPTION
A helper to do to combine `observable.shallow` with `observable.struct`.
Useful when `observable.struct` causes too many reactions and
`observable` would make all children observable. It is used when new
versions of a object come form a rest call or a meteor subscription and\
you are interested in changes at the top level.