### PR TITLE
Fix type parameter passing on OneOf and ManyOf

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,11 @@ Follow the principles in [keepachangelog.com](https://keepachangelog.com)!
 Next version
 =======================================================================================
 
+### Fixed
+
+- Fix type parameter passing in ManyOfImpl and OneOfImpl.
+  This is used when using ManyOf with a custom type, instead of a string.
+  We already had support for this, but it was incomplete.
 
 ### Added
 

--- a/packages/moxb/src/many-of/ManyOfImpl.ts
+++ b/packages/moxb/src/many-of/ManyOfImpl.ts
@@ -4,11 +4,11 @@ import { BindOneOfChoice } from '../one-of/OneOf';
 import { ValueImpl, ValueOptions } from '../value/ValueImpl';
 import { BindManyOfChoice, ManyOf } from './ManyOf';
 
-export interface ManyOfOptions<T> extends ValueOptions<ManyOfImpl, T[]> {
+export interface ManyOfOptions<T> extends ValueOptions<ManyOfImpl<T>, T[]> {
     choices?: ValueOrFunction<BindOneOfChoice<T>[]>;
 }
 
-export class ManyOfImpl<T = string> extends ValueImpl<ManyOfImpl, T[], ManyOfOptions<T>> implements ManyOf<T> {
+export class ManyOfImpl<T = string> extends ValueImpl<ManyOfImpl<T>, T[], ManyOfOptions<T>> implements ManyOf<T> {
     constructor(impl: ManyOfOptions<T>) {
         super(impl);
     }

--- a/packages/moxb/src/one-of/OneOfImpl.ts
+++ b/packages/moxb/src/one-of/OneOfImpl.ts
@@ -3,12 +3,12 @@ import { ValueOrFunction } from '../bind/BindImpl';
 import { ValueImpl, ValueOptions } from '../value/ValueImpl';
 import { BindOneOfChoice, OneOf } from './OneOf';
 
-export interface OneOfOptions<T> extends ValueOptions<OneOfImpl, T> {
+export interface OneOfOptions<T> extends ValueOptions<OneOfImpl<T>, T> {
     choices?: ValueOrFunction<BindOneOfChoice<T>[]>;
     searchData?: (value: string) => BindOneOfChoice<T>[];
 }
 
-export class OneOfImpl<T = string> extends ValueImpl<OneOfImpl, T, OneOfOptions<T>> implements OneOf<T> {
+export class OneOfImpl<T = string> extends ValueImpl<OneOfImpl<T>, T, OneOfOptions<T>> implements OneOf<T> {
     @observable
     _search?: string;
 


### PR DESCRIPTION

In most cases this was already working, but (for example) the type of that `bind` param of the `onSave` function was incomplete.
This type fixes the type definition.