### PR TITLE
Add default comparator function for ManyOfImpl

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,6 +14,9 @@ Next version
 
 ### Added
 
+- Added default comparator function for ManyOfImpl, so the dirty field detection
+  behaves more intuitively for this kind of fields
+
 [v0.2.0-beta.85](https://github.com/moxb/moxb/releases/tag/v0.2.0-beta.84) (2021-08-06)
 =======================================================================================
 

--- a/packages/moxb/src/many-of/ManyOfImpl.ts
+++ b/packages/moxb/src/many-of/ManyOfImpl.ts
@@ -10,7 +10,10 @@ export interface ManyOfOptions<T> extends ValueOptions<ManyOfImpl<T>, T[]> {
 
 export class ManyOfImpl<T = string> extends ValueImpl<ManyOfImpl<T>, T[], ManyOfOptions<T>> implements ManyOf<T> {
     constructor(impl: ManyOfOptions<T>) {
-        super(impl);
+        super({
+            valueCompareFunction: (a, b) => a.sort().toString() === b.sort().toString(),
+            ...impl,
+        });
     }
 
     @computed


### PR DESCRIPTION
This helps with properly detecting the dirty status of fields via the `isInitialValue()` function.

If no comparator function is specified, different arrays with equal contents will be detected as changed, which is false.
