### PR TITLE
Fix multiple file upload, when the upload is called in multiple steps

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,7 @@ Next version
 ### Added
 
 ### Fixed
+- Fix multiple file upload, when the upload is called in multiple steps
 
 ### Changed
 

--- a/packages/moxb/src/file-upload/FileUploadImpl.ts
+++ b/packages/moxb/src/file-upload/FileUploadImpl.ts
@@ -244,12 +244,22 @@ export class FileUploadImpl implements FileUpload {
 
     @action
     upload(file: File | File[]) {
-        this.reset();
-        this._fileList = Array.isArray(file) ? file : [file];
-        this._fileListLength = this._fileList.length;
-        this._pending = true;
-        this._setProgress(0);
-        this.uploadNextFile();
+        if (this._pending) {
+            if (Array.isArray(file)) {
+                this._fileList?.push(...file);
+            } else {
+                this._fileList?.push(file);
+            }
+            this._fileListLength = this._fileList!.length;
+            this._setProgress(this._currentFileIndex / this._fileListLength);
+        } else {
+            this.reset();
+            this._fileList = Array.isArray(file) ? file : [file];
+            this._fileListLength = this._fileList.length;
+            this._setProgress(0);
+            this._pending = true;
+            this.uploadNextFile();
+        }
     }
 
     protected uploadNextFile() {


### PR DESCRIPTION
The antd component now calls the upload() function in multiple steps (it was a change by antd).

Now we can add upload files incrementally.