### PR TITLE
Update Navigation interfaces + fix a bug 

### DIFF
--- a/examples/src/MenuStructure.tsx
+++ b/examples/src/MenuStructure.tsx
@@ -1,6 +1,7 @@
-import { UIFragment, UIFragmentSpec, NavRefRedirect } from '@moxb/antd';
-import { StateSpace, defineNavRef } from '@moxb/moxb';
 import * as React from 'react';
+import { defineNavRef } from '@moxb/moxb';
+import { UIStateSpace } from '@moxb/html';
+import { NavRefRedirect } from '@moxb/antd';
 // @ts-ignore
 import lockImgUrl from '../images/lock.jpg';
 import { ApplicationAnt } from './app/ApplicationAnt';
@@ -14,78 +15,81 @@ import { MoreMenusAnt } from './menus/MoreMenusAnt';
  */
 export const memTableRef = defineNavRef<{ groupId?: string; objectId?: string }>('memTable');
 
-export const mainMenu: StateSpace<UIFragment, UIFragmentSpec, {}> = [
-    {
-        root: true,
-        label: 'All Components',
-        fragment: {
-            main: ApplicationAnt,
-        },
-    },
-    {
-        key: 'loginForm',
-        // hidden: true,
-        label: (
-            <span>
-                <img src={lockImgUrl} width="32" />
-                Login Form
-            </span>
-        ),
-        fragment: {
-            main: LoginFormAnt,
-            bottom: 'Special footer for login form',
-        },
-    },
-    {
-        key: 'memTable',
-        label: 'Mem Table',
-        fragment: {
-            main: MemTableAnt,
-        },
-        tokenMapping: [
-            { key: 'groupId', vanishing: true, defaultValue: 'foo', allowedValues: ['foo', 'bar'] },
-            'objectId',
-        ],
-        // This is where we attach this scheme to this part of the menu tree, meaning that we will
-        // be able to address these states without knowing the path to here.
-        navRef: memTableRef,
-    },
-    {
-        key: 'moreMenus',
-        label: 'More Menus',
-        fragment: {
-            main: MoreMenusAnt,
-        },
-    },
-    {
-        key: 'navRefMagic',
-        label: 'NavRef tricks',
-        subStates: [
-            {
-                key: 'simpleJump',
-                label: 'Simple jump',
-                displayOnly: true,
-                // Here, we are using this NavRef to address a different part of the app.
-                // (This menu item will jump there.)
-                // (This only works if this schema has been attached to somewhere in the menu tree.)
-                navRefCall: memTableRef.call({ groupId: 'foo', objectId: 'William8' }),
+export const mainMenu: UIStateSpace = {
+    metaData: 'Example app main menu',
+    subStates: [
+        {
+            root: true,
+            label: 'All Components',
+            fragment: {
+                main: ApplicationAnt,
             },
-            {
-                key: 'encodedJump',
-                label: 'Encoded jump',
-                displayOnly: true,
-                // Here, we are going to use an encoded link, which stores all in info belonging to
-                // a NavRef call, without knowing anything about the path.
-                pathTokens: ['redirect', memTableRef.call({ groupId: 'bar', objectId: 'Mary1' }).toString()],
+        },
+        {
+            key: 'loginForm',
+            // hidden: true,
+            label: (
+                <span>
+                    <img src={lockImgUrl} width="32" />
+                    Login Form
+                </span>
+            ),
+            fragment: {
+                main: LoginFormAnt,
+                bottom: 'Special footer for login form',
             },
-        ],
-    },
-    {
-        key: 'redirect',
-        hidden: true,
-        fragment: NavRefRedirect,
-    },
-];
+        },
+        {
+            key: 'memTable',
+            label: 'Mem Table',
+            fragment: {
+                main: MemTableAnt,
+            },
+            tokenMapping: [
+                { key: 'groupId', vanishing: true, defaultValue: 'foo', allowedValues: ['foo', 'bar'] },
+                'objectId',
+            ],
+            // This is where we attach this scheme to this part of the menu tree, meaning that we will
+            // be able to address these states without knowing the path to here.
+            navRef: memTableRef,
+        },
+        {
+            key: 'moreMenus',
+            label: 'More Menus',
+            fragment: {
+                main: MoreMenusAnt,
+            },
+        },
+        {
+            key: 'navRefMagic',
+            label: 'NavRef tricks',
+            subStates: [
+                {
+                    key: 'simpleJump',
+                    label: 'Simple jump',
+                    displayOnly: true,
+                    // Here, we are using this NavRef to address a different part of the app.
+                    // (This menu item will jump there.)
+                    // (This only works if this schema has been attached to somewhere in the menu tree.)
+                    navRefCall: memTableRef.call({ groupId: 'foo', objectId: 'William8' }),
+                },
+                {
+                    key: 'encodedJump',
+                    label: 'Encoded jump',
+                    displayOnly: true,
+                    // Here, we are going to use an encoded link, which stores all in info belonging to
+                    // a NavRef call, without knowing anything about the path.
+                    pathTokens: ['redirect', memTableRef.call({ groupId: 'bar', objectId: 'Mary1' }).toString()],
+                },
+            ],
+        },
+        {
+            key: 'redirect',
+            hidden: true,
+            fragment: NavRefRedirect,
+        },
+    ],
+};
 
 export const defaultContent = {
     main: <span>No such content</span>,

--- a/examples/src/MenuStructure.tsx
+++ b/examples/src/MenuStructure.tsx
@@ -89,9 +89,8 @@ export const mainMenu: UIStateSpace = {
             fragment: NavRefRedirect,
         },
     ],
-};
-
-export const defaultContent = {
-    main: <span>No such content</span>,
-    bottom: 'Common footer text',
+    fallback: {
+        main: <span>No such content</span>,
+        bottom: 'Common footer text',
+    },
 };

--- a/examples/src/app/AppRouterAnt.tsx
+++ b/examples/src/app/AppRouterAnt.tsx
@@ -4,7 +4,7 @@ import { Layout, Row } from 'antd';
 import * as React from 'react';
 import { NavigationAnt } from '../common/NavigationAnt';
 
-import { defaultContent, mainMenu } from '../MenuStructure';
+import { mainMenu } from '../MenuStructure';
 
 export class AppRouterAnt extends React.Component {
     render() {
@@ -14,20 +14,9 @@ export class AppRouterAnt extends React.Component {
                     <Row>
                         <NavigationAnt />
                     </Row>
-                    <LocationDependentArea
-                        id="main-area"
-                        stateSpace={mainMenu}
-                        fallback={defaultContent}
-                        part="main"
-                        useTokenMappings={true}
-                    />
+                    <LocationDependentArea id="main-area" stateSpace={mainMenu} part="main" useTokenMappings={true} />
                     <hr />
-                    <LocationDependentArea
-                        id="footer-area"
-                        stateSpace={mainMenu}
-                        fallback={defaultContent}
-                        part="bottom"
-                    />
+                    <LocationDependentArea id="footer-area" stateSpace={mainMenu} part="bottom" />
                 </Layout.Content>
             </Layout>
         );

--- a/examples/src/app/AppRouterAnt.tsx
+++ b/examples/src/app/AppRouterAnt.tsx
@@ -16,7 +16,7 @@ export class AppRouterAnt extends React.Component {
                     </Row>
                     <LocationDependentArea
                         id="main-area"
-                        subStates={mainMenu}
+                        stateSpace={mainMenu}
                         fallback={defaultContent}
                         part="main"
                         useTokenMappings={true}
@@ -24,7 +24,7 @@ export class AppRouterAnt extends React.Component {
                     <hr />
                     <LocationDependentArea
                         id="footer-area"
-                        subStates={mainMenu}
+                        stateSpace={mainMenu}
                         fallback={defaultContent}
                         part="bottom"
                     />

--- a/examples/src/common/NavigationAnt.tsx
+++ b/examples/src/common/NavigationAnt.tsx
@@ -9,6 +9,6 @@ import { mainMenu } from '../MenuStructure';
 @observer
 export class NavigationAnt extends React.Component<UsesLocation & UsesLinkGenerator> {
     render() {
-        return <NavMenuBarAnt id="main-menu" subStates={mainMenu} linkGenerator={this.props.linkGenerator} />;
+        return <NavMenuBarAnt id="main-menu" stateSpace={mainMenu} linkGenerator={this.props.linkGenerator} />;
     }
 }

--- a/examples/src/form/LoginFormAnt.tsx
+++ b/examples/src/form/LoginFormAnt.tsx
@@ -1,4 +1,4 @@
-import { NavigableContent } from '@moxb/moxb';
+import { NavigableUIContent } from '@moxb/html';
 import { ActionButtonAnt, FormAnt, TextFormAnt } from '@moxb/antd';
 import { Row } from 'antd';
 import UserOutlined from '@ant-design/icons/UserOutlined';
@@ -9,7 +9,7 @@ import { Application } from '../app/Application';
 
 @inject('app')
 @observer
-export class LoginFormAnt extends React.Component<{ app?: Application } & NavigableContent<any, any>> {
+export class LoginFormAnt extends React.Component<{ app?: Application } & NavigableUIContent> {
     componentDidMount(): void {
         const { navControl } = this.props;
         navControl.registerStateHooks({

--- a/examples/src/memtable/MemTableAnt.tsx
+++ b/examples/src/memtable/MemTableAnt.tsx
@@ -9,7 +9,7 @@ import { UserInfoAnt } from './UserInfoAnt';
 
 @inject('memTable', 'url')
 @observer
-export class MemTableAnt extends React.Component<{ memTable?: MemTable } & UsesURL & Navigable<any, any>> {
+export class MemTableAnt extends React.Component<{ memTable?: MemTable } & UsesURL & Navigable<any>> {
     render() {
         const memTable = this.props.memTable!;
         const { url, parsedTokens } = this.props;

--- a/examples/src/memtable/UserInfoAnt.tsx
+++ b/examples/src/memtable/UserInfoAnt.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { Navigable, StateSpace } from '@moxb/moxb';
-import { MenuAndContentAnt, OneOfButtonAnt, UIFragmentSpec } from '@moxb/antd';
+import { Navigable } from '@moxb/moxb';
+import { UIStateSpace } from '@moxb/html';
+import { MenuAndContentAnt, OneOfButtonAnt } from '@moxb/antd';
 import { inject, observer } from 'mobx-react';
 import { MemTable } from './MemTable';
 
@@ -10,30 +11,33 @@ export class UserInfoAnt extends React.Component<Navigable<any, any> & { memTabl
     render() {
         const { parsedTokens, memTable } = this.props;
 
-        const userMenu: StateSpace<string, UIFragmentSpec, {}> = [
-            {
-                root: true,
-                label: 'User home',
-                fragment: <div>User home</div>,
-            },
-            {
-                key: 'items',
-                label: 'Items',
-                fragment: (
-                    <div>
-                        User items <OneOfButtonAnt operation={memTable!.item} />
-                    </div>
-                ),
-                tokenMapping: ['itemKey'],
-            },
-        ];
+        const userMenu: UIStateSpace = {
+            metaData: 'User menu of example app',
+            subStates: [
+                {
+                    root: true,
+                    label: 'User home',
+                    fragment: <div>User home</div>,
+                },
+                {
+                    key: 'items',
+                    label: 'Items',
+                    fragment: (
+                        <div>
+                            User items <OneOfButtonAnt operation={memTable!.item} />
+                        </div>
+                    ),
+                    tokenMapping: ['itemKey'],
+                },
+            ],
+        };
 
         return (
             <div>
                 <h2>Selected user: {memTable!.objectId}</h2>
                 <MenuAndContentAnt
                     id={'user-menu'}
-                    subStates={userMenu}
+                    stateSpace={userMenu}
                     parsedTokens={parsedTokens}
                     useTokenMappings={true}
                 />

--- a/examples/src/memtable/UserInfoAnt.tsx
+++ b/examples/src/memtable/UserInfoAnt.tsx
@@ -7,7 +7,7 @@ import { MemTable } from './MemTable';
 
 @inject('memTable')
 @observer
-export class UserInfoAnt extends React.Component<Navigable<any, any> & { memTable?: MemTable }> {
+export class UserInfoAnt extends React.Component<Navigable<any> & { memTable?: MemTable }> {
     render() {
         const { parsedTokens, memTable } = this.props;
 

--- a/examples/src/menus/DetailDisplayer.tsx
+++ b/examples/src/menus/DetailDisplayer.tsx
@@ -1,12 +1,12 @@
-import { UIFragmentSpec } from '@moxb/antd';
-import { getParsedPathTokens, NavigableContent, UsesLocation } from '@moxb/moxb';
+import { getParsedPathTokens, UsesLocation } from '@moxb/moxb';
+import { NavigableUIContent } from '@moxb/html';
 import { inject, observer } from 'mobx-react';
 import * as React from 'react';
 import { UsesURL } from '../store/UrlStore';
 
 @inject('locationManager', 'url')
 @observer
-export class DetailDisplayer extends React.Component<NavigableContent<any, UIFragmentSpec> & UsesLocation & UsesURL> {
+export class DetailDisplayer extends React.Component<NavigableUIContent & UsesLocation & UsesURL> {
     componentDidMount() {
         this.props.navControl.registerStateHooks({
             getLeaveQuestion: () => 'Do you really want to leave behind the details?',

--- a/examples/src/menus/MoreMenusAnt.tsx
+++ b/examples/src/menus/MoreMenusAnt.tsx
@@ -1,14 +1,15 @@
-import { NavLink, NavLinkButtonAnt, MenuAndContentAnt, TextFormAnt, UIFragmentSpec, NavTabBarAnt } from '@moxb/antd';
-import { NavigableContent, setArg } from '@moxb/moxb';
-
-import { Col, Row } from 'antd';
-import { inject } from 'mobx-react';
 import * as React from 'react';
+import { inject } from 'mobx-react';
+import { Col, Row } from 'antd';
+import { setArg } from '@moxb/moxb';
+import { NavigableUIContent } from '@moxb/html';
+import { NavLink, NavLinkButtonAnt, MenuAndContentAnt, TextFormAnt, NavTabBarAnt } from '@moxb/antd';
+
 import { UrlStore } from '../store/UrlStore';
 import { subMenu1, subMenu2 } from './SubMenu';
 
 @inject('url')
-export class MoreMenusAnt extends React.Component<{ url?: UrlStore } & NavigableContent<any, UIFragmentSpec>> {
+export class MoreMenusAnt extends React.Component<{ url?: UrlStore } & NavigableUIContent> {
     render() {
         const { url, navControl } = this.props;
         const { color, search } = url!;
@@ -26,7 +27,6 @@ export class MoreMenusAnt extends React.Component<{ url?: UrlStore } & Navigable
                             navControl={navControl}
                             mode="horizontal"
                             useTokenMappings={true}
-                            fallback="Unknown number"
                             debug={false}
                         />
                     </Col>
@@ -57,7 +57,6 @@ export class MoreMenusAnt extends React.Component<{ url?: UrlStore } & Navigable
                             mode="left"
                             stateSpace={subMenu2}
                             navControl={navControl}
-                            fallback="Unknown color"
                             debug={false}
                         />
                     </Col>

--- a/examples/src/menus/MoreMenusAnt.tsx
+++ b/examples/src/menus/MoreMenusAnt.tsx
@@ -22,7 +22,7 @@ export class MoreMenusAnt extends React.Component<{ url?: UrlStore } & Navigable
                             id="left-menu"
                             parsedTokens={this.props.parsedTokens}
                             // arg={url!.number}
-                            subStates={subMenu1}
+                            stateSpace={subMenu1}
                             navControl={navControl}
                             mode="horizontal"
                             useTokenMappings={true}
@@ -55,7 +55,7 @@ export class MoreMenusAnt extends React.Component<{ url?: UrlStore } & Navigable
                             id="right-menu"
                             arg={color}
                             mode="left"
-                            subStates={subMenu2}
+                            stateSpace={subMenu2}
                             navControl={navControl}
                             fallback="Unknown color"
                             debug={false}

--- a/examples/src/menus/SubMenu.tsx
+++ b/examples/src/menus/SubMenu.tsx
@@ -1,5 +1,5 @@
-import { rootOrDetails, UIFragmentSpec } from '@moxb/antd';
-import { NavigableContent, StateSpace } from '@moxb/moxb';
+import { NavigableUIContent, UIStateSpace } from '@moxb/html';
+import { rootOrDetails } from '@moxb/antd';
 import * as React from 'react';
 // @ts-ignore
 import blueUrl from '../../images/blue_blocks.png';
@@ -15,89 +15,92 @@ import threeUrl from '../../images/three_apples.jpg';
 import twoUrl from '../../images/two_apples.jpg';
 import { DetailDisplayer } from './DetailDisplayer';
 
-export const subMenu1: StateSpace<string, UIFragmentSpec, {}> = [
-    {
-        key: 'one',
-        root: true,
-        label: 'One',
-        fragment: (
-            <div>
-                One apple: <br />
-                <img src={oneUrl} />
-            </div>
-        ),
-    },
-    {
-        key: 'two',
-        label: 'Two',
-        fragment: (
-            <div>
-                Two apples: <br />
-                <img src={twoUrl} />
-            </div>
-        ),
-    },
-    {
-        key: 'three',
-        label: 'Three',
-        tokenMapping: ['something'],
-        fragment: rootOrDetails({
-            ifRoot: {
-                fragment: (
-                    <div>
-                        Three apples: <br />
-                        <img src={threeUrl} />
-                    </div>
-                ),
-            },
-            ifDetails: {
-                fragment: DetailDisplayer,
-            },
-        }),
-    },
-    {
-        key: 'thirty',
-        label: 'Thirty something',
-        // this is a default sub-stace group, so all these sub-states will have "thirty" in their path
-        subStates: [
-            {
-                key: '',
-                root: true,
-                label: 'Thirty',
-                fragment: <div>Number 30</div>,
-            },
-            {
-                key: 'two',
-                label: 'Thirty two',
-                fragment: <div>Number 32</div>,
-            },
-            {
-                key: 'three',
-                label: 'Thirty three',
-                fragment: <div>Number 33</div>,
-            },
-        ],
-    },
-    {
-        key: 'more',
-        label: 'Even more',
-        flat: true, // this means that "more" won't be part of the path for these sub-states
-        subStates: [
-            {
-                key: 'forty',
-                label: 'Forty',
-                fragment: <div>Number 40</div>,
-            },
-            {
-                key: 'fifty',
-                label: 'Fifty',
-                fragment: <div>Number 50</div>,
-            },
-        ],
-    },
-];
+export const subMenu1: UIStateSpace = {
+    metaData: 'Example sub menu 1',
+    subStates: [
+        {
+            key: 'one',
+            root: true,
+            label: 'One',
+            fragment: (
+                <div>
+                    One apple: <br />
+                    <img src={oneUrl} />
+                </div>
+            ),
+        },
+        {
+            key: 'two',
+            label: 'Two',
+            fragment: (
+                <div>
+                    Two apples: <br />
+                    <img src={twoUrl} />
+                </div>
+            ),
+        },
+        {
+            key: 'three',
+            label: 'Three',
+            tokenMapping: ['something'],
+            fragment: rootOrDetails({
+                ifRoot: {
+                    fragment: (
+                        <div>
+                            Three apples: <br />
+                            <img src={threeUrl} />
+                        </div>
+                    ),
+                },
+                ifDetails: {
+                    fragment: DetailDisplayer,
+                },
+            }),
+        },
+        {
+            key: 'thirty',
+            label: 'Thirty something',
+            // this is a default sub-stace group, so all these sub-states will have "thirty" in their path
+            subStates: [
+                {
+                    key: '',
+                    root: true,
+                    label: 'Thirty',
+                    fragment: <div>Number 30</div>,
+                },
+                {
+                    key: 'two',
+                    label: 'Thirty two',
+                    fragment: <div>Number 32</div>,
+                },
+                {
+                    key: 'three',
+                    label: 'Thirty three',
+                    fragment: <div>Number 33</div>,
+                },
+            ],
+        },
+        {
+            key: 'more',
+            label: 'Even more',
+            flat: true, // this means that "more" won't be part of the path for these sub-states
+            subStates: [
+                {
+                    key: 'forty',
+                    label: 'Forty',
+                    fragment: <div>Number 40</div>,
+                },
+                {
+                    key: 'fifty',
+                    label: 'Fifty',
+                    fragment: <div>Number 50</div>,
+                },
+            ],
+        },
+    ],
+};
 
-class GreenBlocks extends React.Component<NavigableContent<string, UIFragmentSpec>> {
+class GreenBlocks extends React.Component<NavigableUIContent> {
     componentDidMount(): void {
         const { navControl } = this.props;
         navControl.registerStateHooks({
@@ -117,31 +120,34 @@ class GreenBlocks extends React.Component<NavigableContent<string, UIFragmentSpe
     }
 }
 
-export const subMenu2: StateSpace<string, UIFragmentSpec, {}> = [
-    {
-        key: 'red',
-        label: 'Red',
-        fragment: (
-            <div>
-                Red blocks: <br />
-                <img src={redUrl} />
-            </div>
-        ),
-    },
-    {
-        key: 'blue',
-        label: 'Blue',
-        title: 'Like the oceans',
-        fragment: (
-            <div>
-                Blue blocks: <br />
-                <img src={blueUrl} />
-            </div>
-        ),
-    },
-    {
-        key: 'green',
-        label: 'Green',
-        fragment: GreenBlocks,
-    },
-];
+export const subMenu2: UIStateSpace = {
+    metaData: 'Example sub-menu 2',
+    subStates: [
+        {
+            key: 'red',
+            label: 'Red',
+            fragment: (
+                <div>
+                    Red blocks: <br />
+                    <img src={redUrl} />
+                </div>
+            ),
+        },
+        {
+            key: 'blue',
+            label: 'Blue',
+            title: 'Like the oceans',
+            fragment: (
+                <div>
+                    Blue blocks: <br />
+                    <img src={blueUrl} />
+                </div>
+            ),
+        },
+        {
+            key: 'green',
+            label: 'Green',
+            fragment: GreenBlocks,
+        },
+    ],
+};

--- a/examples/src/menus/SubMenu.tsx
+++ b/examples/src/menus/SubMenu.tsx
@@ -98,6 +98,7 @@ export const subMenu1: UIStateSpace = {
             ],
         },
     ],
+    fallback: 'Unknown number',
 };
 
 class GreenBlocks extends React.Component<NavigableUIContent> {
@@ -150,4 +151,5 @@ export const subMenu2: UIStateSpace = {
             fragment: GreenBlocks,
         },
     ],
+    fallback: 'Unknown color',
 };

--- a/examples/src/menus/TokenDisplayer.tsx
+++ b/examples/src/menus/TokenDisplayer.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 
 @inject('locationManager')
 @observer
-export class TokenDisplayer extends React.Component<Navigable<any, UIFragmentSpec> & UsesLocation> {
+export class TokenDisplayer extends React.Component<Navigable<UIFragmentSpec> & UsesLocation> {
     public render() {
         return (
             <div>

--- a/examples/src/store/Store.ts
+++ b/examples/src/store/Store.ts
@@ -39,7 +39,7 @@ export class StoreImpl implements Store {
         this.view = new ViewStoreImpl();
         this.linkGenerator = new LinkGeneratorImpl({
             locationManager: this.locationManager,
-            states: mainMenu,
+            stateSpace: mainMenu,
             rootUrl: 'https://localhost:3100',
         });
     }

--- a/packages/antd/src/routing/MultiStepProcessAnt.tsx
+++ b/packages/antd/src/routing/MultiStepProcessAnt.tsx
@@ -53,11 +53,11 @@ export class MultiStepProcessAnt extends React.Component<MultiStepProcessProps<a
         };
         return (
             <div data-testid={id}>
-                <NavStepsAnt arg={currentStep} id={id + '-steps-indicator'} subStates={steps} stepProps={stepProps} />
+                <NavStepsAnt arg={currentStep} id={id + '-steps-indicator'} stateSpace={steps} stepProps={stepProps} />
                 {failed ? (
                     this.renderError()
                 ) : (
-                    <LocationDependentArea arg={currentStep} id={id + '-steps'} subStates={steps} />
+                    <LocationDependentArea arg={currentStep} id={id + '-steps'} stateSpace={steps} />
                 )}
             </div>
         );

--- a/packages/antd/src/routing/NavMenuBarAnt.tsx
+++ b/packages/antd/src/routing/NavMenuBarAnt.tsx
@@ -25,10 +25,24 @@ export interface NavMenuProps<DataType>
     style?: React.CSSProperties;
 
     /**
-     * Menu alignment mode. (Default is 'horizontal')
+     * Menu alignment mode.
+     *
+     * Valid values are "horizontal", "vertical", "inline".
+     * (Default is 'horizontal')
      */
     mode?: MenuMode;
+
+    /**
+     * What triggers sub-menus to open?
+     *
+     * Valid values are "hover" (the default) and "click".
+     */
     triggerSubMenuAction?: TriggerSubMenuAction;
+
+    /**
+     * In case of an inline menu, how do we decide about which groups are open and closed?
+     */
+    openGroups?: 'force-closed' | 'start-closed' | 'default' | 'start-open' | 'force-open';
 }
 
 @inject('locationManager')
@@ -132,15 +146,40 @@ export class NavMenuBarAnt<DataType> extends React.Component<NavMenuProps<DataTy
         // AndD's Menu is smart enough to automatically indicate active state
         // on all groups, so we only ask for the leaves.
         const selectedMenuKeys = states.getActiveSubStateMenuKeys(true);
-        const { extras = [], style, mode = 'horizontal', triggerSubMenuAction } = this.props;
+        const { extras = [], style, mode = 'horizontal', triggerSubMenuAction, openGroups = 'default' } = this.props;
         const actualStyle: React.CSSProperties = { ...style };
         if (mode === 'horizontal') {
             actualStyle.width = '100%';
         }
+        const openProps: {
+            openKeys?: string[];
+            defaultOpenKeys?: string[];
+        } = {};
+        if (mode === 'inline') {
+            const groupKeys = states._subStatesInContext.filter((s) => !!s.subStates).map((s) => s.menuKey);
+            switch (openGroups) {
+                case 'force-closed':
+                    openProps.openKeys = [];
+                    break;
+                case 'start-closed':
+                    openProps.defaultOpenKeys = [];
+                    break;
+                case 'default':
+                    break;
+                case 'start-open':
+                    openProps.defaultOpenKeys = groupKeys;
+                    break;
+                case 'force-open':
+                    openProps.openKeys = groupKeys;
+            }
+        }
+
         return (
             <Menu
                 triggerSubMenuAction={triggerSubMenuAction}
                 selectedKeys={selectedMenuKeys}
+                // defaultOpenKeys={defaultOpenKeys}
+                {...openProps}
                 mode={mode}
                 style={actualStyle}
             >

--- a/packages/html/src/LocationDependentArea.tsx
+++ b/packages/html/src/LocationDependentArea.tsx
@@ -2,6 +2,8 @@ import {
     LocationDependentStateSpaceHandler,
     LocationDependentStateSpaceHandlerImpl,
     LocationDependentStateSpaceHandlerProps,
+    NavigableContent,
+    StateSpace,
     SubStateInContext,
 } from '@moxb/moxb';
 import { inject, observer } from 'mobx-react';
@@ -9,6 +11,9 @@ import * as React from 'react';
 import { renderSubStateCore } from './rendering';
 import { UIFragment } from './UIFragment';
 import { UIFragmentSpec } from './UIFragmentSpec';
+
+export type UIStateSpace<DataType = {}> = StateSpace<UIFragment, UIFragmentSpec, DataType>;
+export type NavigableUIContent = NavigableContent<UIFragment, UIFragmentSpec>;
 
 export interface LocationDependentAreaProps<DataType>
     extends LocationDependentStateSpaceHandlerProps<UIFragment, UIFragmentSpec, DataType> {
@@ -50,38 +55,41 @@ export interface LocationDependentAreaProps<DataType>
 @inject('locationManager', 'tokenManager')
 @observer
 export class LocationDependentArea<DataType> extends React.Component<LocationDependentAreaProps<DataType>> {
-    protected readonly _states: LocationDependentStateSpaceHandler<UIFragment, UIFragmentSpec, DataType>;
-
     public constructor(props: LocationDependentAreaProps<DataType>) {
         super(props);
-
-        const { id, part, fallback, mountAll, useTokenMappings, ...remnantProps } = props;
-        this._states = new LocationDependentStateSpaceHandlerImpl({
-            ...remnantProps,
-            id: 'changing content of ' + id,
-            intercept: true,
-        });
     }
 
-    public componentDidMount() {
+    componentDidMount() {
         if (this.props.useTokenMappings) {
-            this._states.registerTokenMappings();
+            const states = this._getStates(this.props);
+            states.registerTokenMappings();
         }
     }
 
-    public componentWillUnmount() {
+    componentWillUnmount() {
         if (this.props.useTokenMappings) {
-            this._states.unregisterTokenMappings();
+            const states = this._getStates(this.props);
+            states.unregisterTokenMappings();
         }
     }
 
-    public debugLog(...messages: any[]) {
+    componentDidUpdate(prevProps: Readonly<LocationDependentAreaProps<DataType>>) {
+        if (this.props.useTokenMappings) {
+            const prevStates = this._getStates(prevProps);
+            prevStates.unregisterTokenMappings();
+            const newStates = this._getStates(this.props);
+            newStates.registerTokenMappings();
+        }
+    }
+
+    debugLog(...messages: any[]) {
         if (this.props.debug) {
-            (console as any).log(...messages);
+            (console as any).log(`LDA "${this.props.id}":`, ...messages);
         }
     }
 
-    protected renderSubState(
+    renderSubState(
+        states: LocationDependentStateSpaceHandler<UIFragment, UIFragmentSpec, DataType>,
         subState: SubStateInContext<UIFragment, UIFragmentSpec, DataType> | null,
         invisible?: boolean
     ) {
@@ -105,22 +113,55 @@ export class LocationDependentArea<DataType> extends React.Component<LocationDep
                 isActive: () =>
                     (!navControl || navControl.isActive()) && // Is the whole area active?
                     !!subState && // The fallback is never really considered to be active
-                    this._states.isSubStateActive(subState), // Is the current sub-state active?
+                    states.isSubStateActive(subState), // Is the current sub-state active?
                 registerStateHooks: (hooks, componentId?) =>
-                    this._states.registerNavStateHooksForSubState(subState!, hooks, componentId),
+                    states.registerNavStateHooksForSubState(subState!, hooks, componentId),
                 unregisterStateHooks: (componentId?) =>
-                    this._states.unregisterNavStateHooksForSubState(subState!, componentId),
+                    states.unregisterNavStateHooksForSubState(subState!, componentId),
             },
         });
     }
 
-    public render() {
-        const { mountAll } = this.props;
-        const wantedChild = this._states.getActiveSubState();
+    private _getStates(props: LocationDependentAreaProps<DataType>) {
+        const {
+            id,
+            part,
+            fallback,
+            mountAll,
+            // useTokenMappings,
+            ...remnantProps
+        } = props;
+        const states: LocationDependentStateSpaceHandler<
+            UIFragment,
+            UIFragmentSpec,
+            DataType
+        > = new LocationDependentStateSpaceHandlerImpl({
+            ...remnantProps,
+            id: 'changing content of ' + id,
+            intercept: true,
+        });
+        return states;
+    }
+
+    render() {
+        this.debugLog(` *** Rendering with state space "${this.props.stateSpace.metaData}"`);
+
+        const {
+            // id,
+            // part,
+            // fallback,
+            mountAll,
+            // useTokenMappings,
+            // ...remnantProps
+        } = this.props;
+
+        const states = this._getStates(this.props);
+
+        const wantedChild = states.getActiveSubState();
         this.debugLog('wantedChild is', wantedChild);
         if (mountAll && wantedChild) {
             this.debugLog('Rendering all children at once');
-            return this._states
+            return states
                 .getFilteredSubStates({
                     onlyVisible: false,
                     onlyLeaves: true,
@@ -129,11 +170,11 @@ export class LocationDependentArea<DataType> extends React.Component<LocationDep
                 })
                 .map((s, i) => (
                     <div key={`${i}`} style={s !== wantedChild ? { display: 'none' } : s.containerStyle}>
-                        {this.renderSubState(s, s !== wantedChild)}
+                        {this.renderSubState(states, s, s !== wantedChild)}
                     </div>
                 ));
         } else {
-            return this.renderSubState(wantedChild);
+            return this.renderSubState(states, wantedChild);
         }
     }
 }

--- a/packages/html/src/LocationDependentArea.tsx
+++ b/packages/html/src/LocationDependentArea.tsx
@@ -13,7 +13,7 @@ import { UIFragment } from './UIFragment';
 import { UIFragmentSpec } from './UIFragmentSpec';
 
 export type UIStateSpace<DataType = {}> = StateSpace<UIFragment, UIFragmentSpec, DataType>;
-export type NavigableUIContent = NavigableContent<UIFragment, UIFragmentSpec>;
+export type NavigableUIContent = NavigableContent<UIFragmentSpec>;
 
 export interface LocationDependentAreaProps<DataType>
     extends LocationDependentStateSpaceHandlerProps<UIFragment, UIFragmentSpec, DataType> {
@@ -26,11 +26,6 @@ export interface LocationDependentAreaProps<DataType>
      * you can skip this/
      * */
     part?: string;
-
-    /**
-     * What to show when a given sub-state doesn't specify any content
-     */
-    fallback?: UIFragmentSpec;
 
     /**
      * Should we use the token mappings defined for the sub-states?
@@ -91,6 +86,7 @@ export class LocationDependentArea<DataType> extends React.Component<LocationDep
     renderSubState(
         states: LocationDependentStateSpaceHandler<UIFragment, UIFragmentSpec, DataType>,
         subState: SubStateInContext<UIFragment, UIFragmentSpec, DataType> | null,
+        fallback: UIFragmentSpec | undefined,
         invisible?: boolean
     ) {
         const { navControl, id } = this.props;
@@ -103,6 +99,7 @@ export class LocationDependentArea<DataType> extends React.Component<LocationDep
         const parentName = 'LocationDependentArea:' + id + ':' + (subState ? subState.menuKey : 'null');
         return renderSubStateCore({
             state: subState,
+            fallback,
             navigationContext: this.props,
             tokenIncrease: subState ? subState.totalPathTokens.length : 1,
             checkCondition: false, // We don't ever get to select this sub-state if the condition fails
@@ -126,7 +123,6 @@ export class LocationDependentArea<DataType> extends React.Component<LocationDep
         const {
             id,
             part,
-            fallback,
             mountAll,
             // useTokenMappings,
             ...remnantProps
@@ -153,7 +149,10 @@ export class LocationDependentArea<DataType> extends React.Component<LocationDep
             mountAll,
             // useTokenMappings,
             // ...remnantProps
+            stateSpace,
         } = this.props;
+
+        const { fallback } = stateSpace;
 
         const states = this._getStates(this.props);
 
@@ -170,11 +169,11 @@ export class LocationDependentArea<DataType> extends React.Component<LocationDep
                 })
                 .map((s, i) => (
                     <div key={`${i}`} style={s !== wantedChild ? { display: 'none' } : s.containerStyle}>
-                        {this.renderSubState(states, s, s !== wantedChild)}
+                        {this.renderSubState(states, s, fallback, s !== wantedChild)}
                     </div>
                 ));
         } else {
-            return this.renderSubState(states, wantedChild);
+            return this.renderSubState(states, wantedChild, fallback);
         }
     }
 }

--- a/packages/html/src/NavRefRedirect.tsx
+++ b/packages/html/src/NavRefRedirect.tsx
@@ -19,7 +19,7 @@ import * as React from 'react';
  */
 @inject('locationManager', 'linkGenerator')
 @observer
-export class NavRefRedirect extends React.Component<UsesLocation & Navigable<any, any> & UsesLinkGenerator> {
+export class NavRefRedirect extends React.Component<UsesLocation & Navigable<any> & UsesLinkGenerator> {
     @observable
     private _failed = false;
 

--- a/packages/html/src/UIFragmentSpec.ts
+++ b/packages/html/src/UIFragmentSpec.ts
@@ -10,7 +10,7 @@ import { isForwardRef } from './isForwardRef';
  * The use case is that sometimes we want to specify the UI in multiple parts, which can then be inserted
  * to the page at multiple locations. (Like in slots.)
  */
-interface UIFragmentMap {
+export interface UIFragmentMap {
     [id: string]: UIFragment | undefined;
 }
 

--- a/packages/html/src/index.ts
+++ b/packages/html/src/index.ts
@@ -1,9 +1,14 @@
 export * from './ActionHtml';
 export * from './BindHtml';
 
-export { LocationDependentArea, LocationDependentAreaProps } from './LocationDependentArea';
+export {
+    UIStateSpace,
+    NavigableUIContent,
+    LocationDependentArea,
+    LocationDependentAreaProps,
+} from './LocationDependentArea';
 export { UIFragment, renderUIFragment } from './UIFragment';
-export { UIFragmentSpec, extractUIFragmentFromSpec } from './UIFragmentSpec';
+export { UIFragmentMap, UIFragmentSpec, extractUIFragmentFromSpec } from './UIFragmentSpec';
 export { Anchor } from './Anchor';
 export { rootOrDetails, DetailProps } from './rootOrDetails';
 export { renderFallback } from './rendering';

--- a/packages/html/src/rendering.ts
+++ b/packages/html/src/rendering.ts
@@ -2,12 +2,11 @@ import { Navigable, NavigableContent, SubStateCoreInfo, NavControl } from '@moxb
 import { renderUIFragment } from './UIFragment';
 import { extractUIFragmentFromSpec, UIFragmentSpec } from './UIFragmentSpec';
 
-export function renderFallback(props: Navigable<UIFragmentSpec, any>) {
-    const { filterCondition, fallback, part, parsedTokens } = props;
-    const navigableChildParams: Navigable<UIFragmentSpec, any> = {
+export function renderFallback(props: Navigable<any>, fallback: UIFragmentSpec | undefined) {
+    const { filterCondition, part, parsedTokens } = props;
+    const navigableChildParams: Navigable<any> = {
         parsedTokens,
         filterCondition,
-        fallback,
         part,
     };
     const fallbackFragment = extractUIFragmentFromSpec({}, fallback, part);
@@ -16,7 +15,8 @@ export function renderFallback(props: Navigable<UIFragmentSpec, any>) {
 
 interface RenderProps<DataType> {
     state: SubStateCoreInfo<UIFragmentSpec, DataType> | null;
-    navigationContext: Navigable<UIFragmentSpec, DataType>;
+    fallback?: UIFragmentSpec | undefined;
+    navigationContext: Navigable<DataType>;
     tokenIncrease?: number;
     extraProps?: any;
     checkCondition?: boolean;
@@ -24,16 +24,23 @@ interface RenderProps<DataType> {
 }
 
 export function renderSubStateCore<DataType>(props: RenderProps<DataType>) {
-    const { state, navigationContext, tokenIncrease = 0, extraProps = {}, checkCondition, navControl } = props;
-    const { filterCondition, parsedTokens, fallback, part } = navigationContext;
+    const {
+        state,
+        fallback,
+        navigationContext,
+        tokenIncrease = 0,
+        extraProps = {},
+        checkCondition,
+        navControl,
+    } = props;
+    const { filterCondition, parsedTokens, part } = navigationContext;
     if (checkCondition && state && state.data && filterCondition) {
         if (!filterCondition(state.data)) {
-            return renderFallback(navigationContext);
+            return renderFallback(navigationContext, fallback);
         }
     }
-    const navigableChildParams: NavigableContent<UIFragmentSpec, DataType> = {
+    const navigableChildParams: NavigableContent<DataType> = {
         parsedTokens: (parsedTokens || 0) + tokenIncrease,
-        fallback,
         filterCondition,
         part,
         navControl,

--- a/packages/html/src/rootOrDetails.tsx
+++ b/packages/html/src/rootOrDetails.tsx
@@ -20,7 +20,7 @@ interface OwnProps<DataType> {
     ifDetails: SubStateCoreInfo<UIFragmentSpec, DataType>;
 }
 
-type ComponentProps<DataType> = UsesLocation & NavigableContent<UIFragmentSpec, DataType>;
+type ComponentProps<DataType> = UsesLocation & NavigableContent<DataType>;
 
 export interface DetailProps {
     token: string;

--- a/packages/moxb/src/routing/TokenManager.ts
+++ b/packages/moxb/src/routing/TokenManager.ts
@@ -21,7 +21,7 @@ export interface TokenMappings<DataType> {
      *
      * This should be the same information that is powering the menu system.
      */
-    subStates: StateSpace<any, any, DataType>;
+    stateSpace: StateSpace<any, any, DataType>;
 
     /**
      * The number of path tokens to ignore

--- a/packages/moxb/src/routing/TokenManagerImpl.ts
+++ b/packages/moxb/src/routing/TokenManagerImpl.ts
@@ -144,7 +144,7 @@ export class TokenManagerImpl implements TokenManager {
      */
     @action
     addMappings<DataType>(mappings: TokenMappings<DataType>) {
-        const { id, subStates, parsedTokens = 0, filterCondition } = mappings;
+        const { id, stateSpace, parsedTokens = 0, filterCondition } = mappings;
         const { debug } = this._config;
         let mappingsId = id;
         while (this._mappingRegistry.get(mappingsId)) {
@@ -153,13 +153,13 @@ export class TokenManagerImpl implements TokenManager {
         this._mappingRegistry.set(mappingsId, {
             type: 'complex',
             id,
-            subStates,
+            stateSpace,
             parsedTokens,
             filterCondition,
             states: new LocationDependentStateSpaceHandlerImpl({
                 id: 'token manager mappings ' + id,
                 locationManager: this._locationManager,
-                subStates,
+                stateSpace,
                 filterCondition,
                 parsedTokens,
                 debug,

--- a/packages/moxb/src/routing/location-state-space/LocationDependentStateSpaceHandler.ts
+++ b/packages/moxb/src/routing/location-state-space/LocationDependentStateSpaceHandler.ts
@@ -10,7 +10,7 @@ export interface LocationDependentStateSpaceHandlerProps<LabelType, WidgetType, 
     extends StateSpaceHandlerProps<LabelType, WidgetType, DataType>,
         UsesLocation,
         UsesTokenManager,
-        Navigable<WidgetType, DataType> {
+        Navigable<DataType> {
     /**
      * The URL argument (if any) driving this component.
      */

--- a/packages/moxb/src/routing/location-state-space/LocationDependentStateSpaceHandler.ts
+++ b/packages/moxb/src/routing/location-state-space/LocationDependentStateSpaceHandler.ts
@@ -43,7 +43,7 @@ export interface LocationDependentStateSpaceHandler<LabelType, WidgetType, DataT
     extends StateSpaceHandler<LabelType, WidgetType, DataType>,
         LocationChangeInterceptor {
     /**
-     * Register the mappings belonging to this state sub-tree on the token manegr
+     * Register the mappings belonging to this state sub-tree on the token manager
      */
     registerTokenMappings(): void;
 

--- a/packages/moxb/src/routing/location-state-space/LocationDependentStateSpaceHandlerImpl.ts
+++ b/packages/moxb/src/routing/location-state-space/LocationDependentStateSpaceHandlerImpl.ts
@@ -130,7 +130,7 @@ export class LocationDependentStateSpaceHandlerImpl<LabelType, WidgetType, DataT
     public registerTokenMappings() {
         this._mappingId = this._tokenManager.addMappings({
             id: 'mappings for ' + this._id,
-            subStates: this._subStates,
+            stateSpace: this._stateSpace,
             parsedTokens: this._parsedTokens,
             filterCondition: this._filterCondition,
         });

--- a/packages/moxb/src/routing/location-state-space/__tests__/LocationDependentStateSpaceHandlerImpl.test.ts
+++ b/packages/moxb/src/routing/location-state-space/__tests__/LocationDependentStateSpaceHandlerImpl.test.ts
@@ -22,7 +22,7 @@ describe('Location-Dependent State-Space-Handler implementation, powered by path
         TestData
     > = new LocationDependentStateSpaceHandlerImpl({
         locationManager,
-        subStates: testStateSpace,
+        stateSpace: testStateSpace,
         filterCondition: (data) => !(data && data.secret), // in menus, we will hide the "secret" items
         id: 'test loc dep state-space handler 1 (path based)',
         // no parsed tokens first
@@ -146,7 +146,7 @@ describe('Location-Dependent State-Space-Handler implementation, powered by url 
 
     const handler = new LocationDependentStateSpaceHandlerImpl({
         locationManager,
-        subStates: testStateSpace,
+        stateSpace: testStateSpace,
         filterCondition: (data) => !(data && data.secret), // in menus, we will hide the "secret" items
         id: 'test loc dep state-space handler 2 (arg based)',
         arg: where,
@@ -267,7 +267,7 @@ describe('Location-Dependent State-Space-Handler implementation, powered by path
 
     const handler = new LocationDependentStateSpaceHandlerImpl({
         locationManager,
-        subStates: testStateSpace,
+        stateSpace: testStateSpace,
         filterCondition: (data) => !(data && data.secret), // in menus, we will hide the "secret" items
         id: 'test loc dep state-space handler 3 (path based, with prefix)',
         parsedTokens: 1, // The first token on the path will be ignored

--- a/packages/moxb/src/routing/location-state-space/state-space/StateSpace.ts
+++ b/packages/moxb/src/routing/location-state-space/state-space/StateSpace.ts
@@ -150,8 +150,20 @@ export interface SubState<LabelType, WidgetType, DataType>
  * The totality of all possible states for a given part of the app UI
  */
 export interface StateSpace<LabelType, WidgetType, DataType> {
+    /**
+     * Generic data related to this state space, if any
+     */
     metaData: string;
+
+    /**
+     * The list of possible sub-states within this state
+     */
     subStates: SubState<LabelType, WidgetType, DataType>[];
+
+    /**
+     * How do we define the sub-state in case we are at an undefined location?
+     */
+    fallback?: WidgetType;
 }
 
 /**

--- a/packages/moxb/src/routing/location-state-space/state-space/StateSpace.ts
+++ b/packages/moxb/src/routing/location-state-space/state-space/StateSpace.ts
@@ -149,10 +149,13 @@ export interface SubState<LabelType, WidgetType, DataType>
 /**
  * The totality of all possible states for a given part of the app UI
  */
-export type StateSpace<LabelType, WidgetType, DataType> = SubState<LabelType, WidgetType, DataType>[];
+export interface StateSpace<LabelType, WidgetType, DataType> {
+    metaData: string;
+    subStates: SubState<LabelType, WidgetType, DataType>[];
+}
 
 /**
- * This interface describes how the identify a sub-state within a state-space
+ * This interface describes how to identify a sub-state within a state-space
  */
 export interface SubStateInContext<LabelType, WidgetType, DataType> extends SubState<LabelType, WidgetType, DataType> {
     /**
@@ -175,6 +178,11 @@ export interface SubStateInContext<LabelType, WidgetType, DataType> extends SubS
      * The menu key generated for this sub-state
      */
     menuKey: string;
+
+    /**
+     * Mete-data about the original state-space where this sub-state comes from
+     */
+    metaData: any;
 
     /**
      * We are restricting the SubStates array so that we know that they all must have context, too

--- a/packages/moxb/src/routing/location-state-space/state-space/StateSpaceHandler.ts
+++ b/packages/moxb/src/routing/location-state-space/state-space/StateSpaceHandler.ts
@@ -123,7 +123,7 @@ export interface StateSpaceHandlerProps<LabelType, WidgetType, DataType> {
     /**
      * The list of sub-states to work with
      */
-    subStates: StateSpace<LabelType, WidgetType, DataType>;
+    stateSpace: StateSpace<LabelType, WidgetType, DataType>;
 
     /**
      * An optional condition to use for filtering when displaying in a menu

--- a/packages/moxb/src/routing/location-state-space/state-space/__tests__/StateSpaceHandlerImpl.test.ts
+++ b/packages/moxb/src/routing/location-state-space/state-space/__tests__/StateSpaceHandlerImpl.test.ts
@@ -3,7 +3,7 @@ import { testStateSpace } from './TestStateSpace';
 
 describe('State-Space Handler implementation', () => {
     const handler = new StateSpaceHandlerImpl({
-        subStates: testStateSpace,
+        stateSpace: testStateSpace,
         filterCondition: (data) => !(data && data.secret), // in menus, we will hide the "secret" items
         id: 'test state space',
         // debug: true,

--- a/packages/moxb/src/routing/location-state-space/state-space/__tests__/TestStateSpace.ts
+++ b/packages/moxb/src/routing/location-state-space/state-space/__tests__/TestStateSpace.ts
@@ -4,57 +4,60 @@ export interface TestData {
     secret: boolean;
 }
 
-export const testStateSpace: StateSpace<string, any, TestData> = [
-    {
-        label: 'Root state',
-        root: true,
-    },
-    {
-        key: 'foo',
-        label: 'Foo',
-    },
-    {
-        key: 'bar',
-        label: 'Bar',
-        hidden: true, // this won't be listed in a menu
-    },
-    {
-        key: 'group1',
-        label: 'Group 1',
-        subStates: [
-            {
-                key: 'child1',
-                label: 'Child 1',
-            },
-            {
-                key: 'child2',
-                label: 'Child 2',
-            },
-            {
-                root: true,
-                label: 'Group 1 Root',
-            },
-        ],
-    },
-    {
-        key: 'group2',
-        label: 'Group 2',
-        flat: true, // This is a flat group, so the sub-states will appear in the same level
-        subStates: [
-            {
-                key: 'child3',
-                label: 'Child 3',
-            },
-            {
-                key: 'child4',
-                label: 'Child 4',
-                data: {
-                    secret: true,
+export const testStateSpace: StateSpace<string, any, TestData> = {
+    metaData: 'Test state-space',
+    subStates: [
+        {
+            label: 'Root state',
+            root: true,
+        },
+        {
+            key: 'foo',
+            label: 'Foo',
+        },
+        {
+            key: 'bar',
+            label: 'Bar',
+            hidden: true, // this won't be listed in a menu
+        },
+        {
+            key: 'group1',
+            label: 'Group 1',
+            subStates: [
+                {
+                    key: 'child1',
+                    label: 'Child 1',
                 },
-            },
-        ],
-    },
-];
+                {
+                    key: 'child2',
+                    label: 'Child 2',
+                },
+                {
+                    root: true,
+                    label: 'Group 1 Root',
+                },
+            ],
+        },
+        {
+            key: 'group2',
+            label: 'Group 2',
+            flat: true, // This is a flat group, so the sub-states will appear in the same level
+            subStates: [
+                {
+                    key: 'child3',
+                    label: 'Child 3',
+                },
+                {
+                    key: 'child4',
+                    label: 'Child 4',
+                    data: {
+                        secret: true,
+                    },
+                },
+            ],
+        },
+    ],
+};
 
 describe('the description of the state-spaces and sub-states', () => {
     it('should look nice', () => {

--- a/packages/moxb/src/routing/navigable.ts
+++ b/packages/moxb/src/routing/navigable.ts
@@ -58,7 +58,7 @@ export interface NavControl {
  * This data structure will be made available to components
  * that are rendered as part of the navigation process
  */
-export interface Navigable<WidgetType, DataType> {
+export interface Navigable<DataType> {
     /**
      * The number of tokens that have already been parsed, is any.
      *
@@ -67,23 +67,22 @@ export interface Navigable<WidgetType, DataType> {
     parsedTokens?: number;
 
     filterCondition?: StateCondition<DataType>;
-    fallback?: WidgetType;
     part?: string;
 }
 
 /**
- * This data structure will be made available to components
+ * This data structure will be made available by their parents to components
  * that are rendered as part of the navigation process,
- * and have own content
+ * and have their own navigable content
  */
-export interface NavigableContent<WidgetType, DataType> extends Navigable<WidgetType, DataType> {
+export interface NavigableContent<DataType> extends Navigable<DataType> {
     navControl: NavControl;
 }
 
 /**
  * Extract the next path token from the location manager, based on the number of parsed tokens passed down
  */
-export function getNextPathToken<WidgetType, DataType>(props: Navigable<WidgetType, DataType> & UsesLocation): string {
+export function getNextPathToken<DataType>(props: Navigable<DataType> & UsesLocation): string {
     const { locationManager, parsedTokens } = props;
     return locationManager!.pathTokens[parsedTokens!];
 }
@@ -91,7 +90,7 @@ export function getNextPathToken<WidgetType, DataType>(props: Navigable<WidgetTy
 /**
  * Extract the already parsed path tokens from the location manager, based on the number of parsed tokens passed down
  */
-export function getParsedPathTokens<WidgetType, DataType>(props: Navigable<WidgetType, DataType> & UsesLocation) {
+export function getParsedPathTokens<DataType>(props: Navigable<DataType> & UsesLocation) {
     const { locationManager, parsedTokens } = props;
     return locationManager!.pathTokens.slice(0, parsedTokens!);
 }

--- a/packages/moxb/src/routing/navigation-references/LinkGenerator.ts
+++ b/packages/moxb/src/routing/navigation-references/LinkGenerator.ts
@@ -25,7 +25,7 @@ export interface LinkGeneratorProps {
     /**
      * What is the state space that we are using to find out where each NavRefs should point it?
      */
-    states: ValueOrFunction<StateSpace<any, any, any>>;
+    stateSpace: ValueOrFunction<StateSpace<any, any, any>>;
 
     /**
      * What is the root URL that we put into the links?

--- a/packages/moxb/src/routing/navigation-references/LinkGeneratorImpl.ts
+++ b/packages/moxb/src/routing/navigation-references/LinkGeneratorImpl.ts
@@ -27,7 +27,7 @@ export class LinkGeneratorImpl implements LinkGenerator {
             this._preparing = true;
             this._states = new StateSpaceHandlerImpl({
                 id: 'link-generator-space',
-                subStates: getValueOrFunction(this.props.states)!,
+                stateSpace: getValueOrFunction(this.props.stateSpace)!,
             });
         }
         return this._states;


### PR DESCRIPTION
This depends on the antd upgrade PR: https://github.com/moxb/moxb/pull/279

**This is a breaking API change. All application code needs to be (slightly) updated.**

The main change is that the definition of the state-space has been extended:
- whenever we are specifying a state-space, now we can also specify
   some central piece of meta-data along with the list of sub-states.
   This is useful for both debugging and other, application-specific purposes.
- Also, the fallback state (which is to be shown when an illegal sub-state is requested)
  is now passed in via the same state-space definition, and not separately to the UI components.
  This is actually more logical, because this information is part of the state-space, and not the UI.

Furthermore, there was a bug which caused the navigation system to behave in an inconsistent way
in some cases when the definition of the menu is changing on the fly (not only our position).
That has been fixed.